### PR TITLE
sync: shared infrastructure scripts from psychology-agent (Session 63)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ state.db-wal
 # Agent identity (machine-local)
 .agent-identity.json
 
+# Local infrastructure overrides (hostnames, SSH users, paths — machine-specific)
+transport/agent-registry.local.json
+
 # Session transcripts tracked via Git LFS (see .gitattributes)

--- a/scripts/autonomous-sync.sh
+++ b/scripts/autonomous-sync.sh
@@ -39,6 +39,7 @@ export MAX_ACTIONS_PER_CYCLE=5  # reserved for evaluator gate (not yet enforced)
 MAX_CONSECUTIVE_ERRORS=2
 GATE_ACCELERATED=false
 GATE_ACCELERATED_INTERVAL=60  # seconds — fast lane when gates active
+TRANSPORT_CHANGED=false  # set by git_sync — true if pull brought transport changes
 LOG_PREFIX="[$(date '+%Y-%m-%dT%H:%M:%S%z')] [${AGENT_ID}]"
 
 # ── Functions ────────────────────────────────────────────────────────────────
@@ -304,10 +305,34 @@ git_sync() {
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>" 2>/dev/null || true
     fi
 
+    # Record HEAD before pull to detect new commits
+    local head_before
+    head_before=$(git rev-parse HEAD)
+
     log "Pulling latest from origin..."
     if ! git pull --rebase origin main 2>&1; then
         err "git pull failed"
         return 1
+    fi
+
+    local head_after
+    head_after=$(git rev-parse HEAD)
+
+    # Check if new commits arrived with transport-relevant changes
+    if [ "${head_before}" = "${head_after}" ]; then
+        TRANSPORT_CHANGED=false
+        log "No new commits from origin"
+    else
+        local transport_files
+        transport_files=$(git diff --name-only "${head_before}" "${head_after}" -- \
+            transport/ .well-known/ 2>/dev/null | head -5)
+        if [ -n "${transport_files}" ]; then
+            TRANSPORT_CHANGED=true
+            log "Transport changes detected: $(echo "${transport_files}" | wc -l | tr -d ' ') files"
+        else
+            TRANSPORT_CHANGED=false
+            log "New commits arrived but no transport changes"
+        fi
     fi
 
     return 0
@@ -428,6 +453,13 @@ main() {
     # Emit heartbeat (mesh presence announcement)
     python3 "${PROJECT_ROOT}/scripts/heartbeat.py" emit >&2 || true
 
+    # Export operational state snapshot for cross-machine visibility
+    if [ -f "${PROJECT_ROOT}/scripts/mesh-state-export.py" ]; then
+        python3 "${PROJECT_ROOT}/scripts/mesh-state-export.py" >&2 || {
+            log "WARNING: mesh-state-export.py failed — continuing without state export"
+        }
+    fi
+
     # Verify shared scripts (warning only — non-blocking)
     if [ -f "${PROJECT_ROOT}/scripts/verify_shared_scripts.py" ]; then
         python3 "${PROJECT_ROOT}/scripts/verify_shared_scripts.py" --quiet 2>/dev/null || {
@@ -454,10 +486,33 @@ main() {
     # standard min_action_interval otherwise
     check_interval
 
-    # Pull latest
+    # Pull latest (sets TRANSPORT_CHANGED)
     if ! git_sync; then
         err "Git sync failed — aborting cycle"
         exit 1
+    fi
+
+    # Pre-flight check: skip expensive claude invocation if nothing changed.
+    # Still invoke if: transport changed, gates active, wake signal, or
+    # unprocessed messages exist in state.db.
+    if [ "${TRANSPORT_CHANGED}" = false ] && [ "${GATE_ACCELERATED}" = false ]; then
+        local unprocessed_count
+        unprocessed_count=$(sqlite3 "${DB_PATH}" \
+            "SELECT COUNT(*) FROM transport_messages WHERE processed = FALSE;" 2>/dev/null || echo "0")
+        if [ "${unprocessed_count}" -eq 0 ]; then
+            log "NO-OP — no transport changes, no active gates, no unprocessed messages. Skipping /sync."
+
+            # Push any local changes (heartbeat, mesh-state) without invoking claude
+            git_push || true
+
+            # Reset consecutive blocks on successful no-op
+            sqlite3 "${DB_PATH}" \
+                "UPDATE trust_budget SET consecutive_blocks = 0 WHERE agent_id = '${AGENT_ID}';"
+
+            log "=== Autonomous sync cycle complete (no-op, budget: ${budget}) ==="
+            exit 0
+        fi
+        log "Unprocessed messages found (${unprocessed_count}) — proceeding with /sync"
     fi
 
     # Run /sync

--- a/scripts/bootstrap_facets.py
+++ b/scripts/bootstrap_facets.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""bootstrap_facets.py — Classify all state.db entities using two vocabularies.
+
+Subject classification: PSH (Polythematic Structured Subject Headings,
+Czech National Library, 44 top-level categories, 13,900+ terms). L1-only
+with L2-ready schema — slash-separated values (e.g., 'psychology/psychometrics')
+earn inclusion through literary warrant.
+
+Type classification: schema.org (W3C vocabulary, 800+ types). Maps each
+entity table to its schema.org type for semantic interoperability.
+
+Plan 9 insight: disciplines are namespaces composed at query time, not
+directories navigated at storage time. Both vocabularies populate the
+universal_facets table.
+
+Replaces: bootstrap_pje_facets.py (PJE domain taxonomy, retired).
+
+Usage:
+    python3 scripts/bootstrap_facets.py                # tag all entities
+    python3 scripts/bootstrap_facets.py --dry-run      # show what would be tagged
+    python3 scripts/bootstrap_facets.py --stats         # show current distribution
+    python3 scripts/bootstrap_facets.py --discover      # find candidate L1/L2 terms
+"""
+
+import argparse
+import re
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_ROOT / "state.db"
+
+
+# ── PSH Subject Classification (L1) ───────────────────────────────────
+#
+# 10 of 44 PSH categories carry warrant in this project's data.
+# Inactive categories (agriculture, mining, sport, etc.) omitted.
+# L2 sub-categories added as 'parent/child' when they earn warrant.
+#
+# Project-local extensions (prefixed 'PL-') cover domains where PSH
+# lacks vocabulary — PSH last substantially updated ~2015, predating
+# multi-agent AI systems entirely. Literary warrant justifies local
+# categories when the canonical vocabulary cannot provide precision.
+#
+# PSH codes reference: https://psh.techlib.cz/skos/en
+
+PSH_CATEGORIES = {
+    # ── PSH9194: psychology ──────────────────────────────────────────
+    "psychology": {
+        "code": "PSH9194",
+        "keywords": {
+            "psq", "dimension", "calibration", "bifactor", "psychometric",
+            "scoring", "construct", "validity", "reliability", "factor",
+            "loadings", "correlation", "measurement", "instrument",
+            "assessment", "human factors", "cognitive", "sycophancy",
+            "socratic", "heuristic", "perception", "bias", "model fit",
+            "rmsea", "cfa", "omega", "icc", "concordance", "dreaddit",
+            "safety quotient", "dignity", "well-being", "threat",
+            "hostility", "resilience", "coping", "distress", "readiness",
+            "recalibrat", "training data", "scorer", "evaluator",
+            "adversarial", "fair witness", "psycholog",
+        },
+    },
+    # ── PSH8808: law ─────────────────────────────────────────────────
+    "law": {
+        "code": "PSH8808",
+        "keywords": {
+            "governance", "trust budget", "obligation", "gate", "fallback",
+            "due process", "authority", "hierarchy", "precedent",
+            "adjudicate", "resolution", "arbiter", "autonomy", "consent",
+            "permission", "license", "apache", "gpl", "compliance",
+            "audit", "accountability", "transparency", "rights",
+            "boundary", "scope", "constraint", "policy", "convention",
+            "rule", "enforcement", "violation", "threshold", "budget",
+            "credential", "secret", "pre-commit", "jurisprud",
+        },
+    },
+    # ── PSH12314: computer technology ────────────────────────────────
+    "computer-technology": {
+        "code": "PSH12314",
+        "keywords": {
+            "schema", "sql", "sqlite", "database", "bootstrap", "migration",
+            "cron", "script", "deploy", "endpoint", "api", "worker",
+            "cloudflare", "hetzner", "git", "remote", "fetch", "push",
+            "commit", "hook", "pipeline", "daemon", "pid", "lock",
+            "dedup", "checksum", "idempotent", "dual write", "state layer",
+            "autonomous sync", "cross-repo", "cli", "claude code",
+        },
+    },
+    # ── PSH6445: information science ─────────────────────────────────
+    "information-science": {
+        "code": "PSH6445",
+        "keywords": {
+            "memory", "indexing", "facet", "taxonomy", "classification",
+            "vocabulary", "controlled vocab", "subject heading", "psh",
+            "schema.org", "metadata", "provenance", "manifest", "registry",
+            "discovery", "orientation payload", "catalog", "quality",
+            "review", "content-quality",
+        },
+    },
+    # ── PSH11322: systems theory ─────────────────────────────────────
+    "systems-theory": {
+        "code": "PSH11322",
+        "keywords": {
+            "cogarch", "cognitive architecture", "trigger", "knock-on",
+            "feedback", "emergent", "cascade", "systems thinking",
+            "von bertalanffy", "interaction", "self-healing",
+        },
+    },
+    # ── PSH2596: philosophy ──────────────────────────────────────────
+    "philosophy": {
+        "code": "PSH2596",
+        "keywords": {
+            "epistemic", "epistemology", "fair witness", "anti-sycophancy",
+            "falsif", "popper", "theory-revising", "speculation",
+            "inference", "observation", "evidence", "warrant", "claim",
+        },
+    },
+    # ── PSH9508: sociology ───────────────────────────────────────────
+    "sociology": {
+        "code": "PSH9508",
+        "keywords": {
+            "dignity index", "weird", "cultural", "community",
+            "interpretant", "audience", "persona", "stakeholder",
+        },
+    },
+    # ── PSH7093: mathematics ─────────────────────────────────────────
+    "mathematics": {
+        "code": "PSH7093",
+        "keywords": {
+            "calibrat", "isotonic", "quantile", "regression", "mse",
+            "mae", "partial correlation", "factor analysis", "bifactor",
+            "eigenvalue", "variance", "binning", "statistical",
+        },
+    },
+    # ── PSH9759: communications ──────────────────────────────────────
+    "communications": {
+        "code": "PSH9759",
+        "keywords": {
+            "interagent", "protocol", "transport", "message", "ack",
+            "session", "mesh", "heartbeat", "sync", "notification",
+            "signal", "relay",
+        },
+    },
+    # ── PSH8126: pedagogy ────────────────────────────────────────────
+    "pedagogy": {
+        "code": "PSH8126",
+        "keywords": {
+            "socratic", "jargon", "pedagogical", "lesson", "learning",
+            "teaching", "tutorial", "onboarding", "guide", "readme",
+        },
+    },
+    # ── PL-001: AI/ML systems (project-local — no PSH equivalent) ──
+    # Literary warrant: 320+ "agent" hits, 93 "model" hits, 30 "claude"
+    # hits in entity text. PSH predates multi-agent AI entirely.
+    "ai-systems": {
+        "code": "PL-001",
+        "keywords": {
+            "llm", "large language model", "embedding", "prompt",
+            "system prompt", "fine-tun", "alignment", "rlhf",
+            "multi-agent", "agentic", "tool use", "context window",
+            "anthropic", "claude code", "agent card", "agent-card",
+            "sub-agent", "peer agent", "evaluator-as-arbiter",
+        },
+    },
+}
+
+# Flatten all keywords for discovery (novel-term detection)
+ALL_KNOWN_KEYWORDS = set()
+for cat in PSH_CATEGORIES.values():
+    ALL_KNOWN_KEYWORDS.update(cat["keywords"])
+
+
+# ── Schema.org Type Classification ─────────────────────────────────────
+#
+# Maps entity tables to schema.org types. Static — each table has one type.
+# Reference: https://schema.org/docs/full.html
+
+SCHEMA_ORG_TYPES = {
+    "transport_messages": "schema:Message",
+    "decision_chain":     "schema:ChooseAction",
+    "session_log":        "schema:Event",
+    "claims":             "schema:Claim",
+    "memory_entries":     "schema:DefinedTerm",
+    "lessons":            "schema:LearningResource",
+    "trigger_state":      "schema:HowToStep",
+    "autonomous_actions": "schema:Action",
+    "active_gates":       "schema:SuspendAction",
+    "epistemic_flags":    "schema:Comment",
+}
+
+# Keyword set version — increment when PSH_CATEGORIES or SCHEMA_ORG_TYPES change.
+# Stored with each facet for provenance + selective reclassification.
+KEYWORD_SET_VERSION = 2  # v1 = PJE era, v2 = PSH + schema.org + ai-systems + coverage gaps
+
+
+# ── Classification Engine ──────────────────────────────────────────────
+
+# Agent IDs that appear in entity text but should not trigger keyword matches.
+# Without this, "psychology-agent" triggers "psycholog" in the psychology category.
+AGENT_ID_NOISE = {
+    "psychology-agent", "psq-sub-agent", "psq-agent",
+    "unratified-agent", "peer-agent", "sub-agent",
+}
+
+
+def _strip_agent_ids(text: str) -> str:
+    """Remove agent IDs from text to prevent false keyword matches."""
+    for agent_id in AGENT_ID_NOISE:
+        text = text.replace(agent_id, "")
+    return text
+
+
+def classify_psh(text: str) -> list[tuple[str, float, list[str]]]:
+    """Return PSH L1 categories matching the text with confidence + matched keywords.
+
+    Returns list of (category, confidence, matched_keywords) tuples.
+    Confidence = keyword_hits / total_keywords_in_category (0.0–1.0).
+    """
+    text_lower = _strip_agent_ids(text.lower())
+    matches = []
+    for category, spec in PSH_CATEGORIES.items():
+        hits = [kw for kw in spec["keywords"] if kw in text_lower]
+        if hits:
+            confidence = min(len(hits) / len(spec["keywords"]), 1.0)
+            matches.append((category, round(confidence, 3), hits))
+    return matches if matches else [("unclassified", 0.0, [])]
+
+
+def classify_psh_simple(text: str) -> list[str]:
+    """Return PSH category names only (for discovery/stats where confidence not needed)."""
+    return [cat for cat, _, _ in classify_psh(text)]
+
+
+def get_connection() -> sqlite3.Connection:
+    """Connect to state.db."""
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _ensure_metadata_columns(conn: sqlite3.Connection) -> None:
+    """Add confidence/keyword_hits/computed_at/keyword_set_version columns if missing.
+
+    Backward-compatible: columns added with defaults so existing rows remain valid.
+    """
+    existing = {
+        row[1] for row in conn.execute("PRAGMA table_info(universal_facets)")
+    }
+    migrations = [
+        ("confidence", "REAL DEFAULT 1.0"),
+        ("keyword_hits", "TEXT"),  # JSON array of matched keywords
+        ("computed_at", "TEXT"),
+        ("keyword_set_version", "INTEGER DEFAULT 1"),
+    ]
+    for col_name, col_def in migrations:
+        if col_name not in existing:
+            conn.execute(
+                f"ALTER TABLE universal_facets ADD COLUMN {col_name} {col_def}"
+            )
+    conn.commit()
+
+
+def collect_entity_text(conn: sqlite3.Connection) -> list[tuple]:
+    """Collect (entity_type, entity_id, text) for all classifiable entities."""
+    entities = []
+
+    for row in conn.execute(
+        "SELECT id, session_name, message_type, subject, from_agent, to_agent "
+        "FROM transport_messages"
+    ).fetchall():
+        text = f"{row[1]} {row[2]} {row[3] or ''} {row[4]} {row[5]}"
+        entities.append(("transport_messages", row[0], text))
+
+    for row in conn.execute(
+        "SELECT id, decision_key, decision_text, evidence_source "
+        "FROM decision_chain"
+    ).fetchall():
+        text = f"{row[1]} {row[2]} {row[3] or ''}"
+        entities.append(("decision_chain", row[0], text))
+
+    for row in conn.execute(
+        "SELECT id, summary, artifacts FROM session_log"
+    ).fetchall():
+        text = f"{row[1]} {row[2] or ''}"
+        entities.append(("session_log", row[0], text))
+
+    for row in conn.execute(
+        "SELECT id, topic, entry_key, value FROM memory_entries"
+    ).fetchall():
+        text = f"{row[1]} {row[2]} {row[3]}"
+        entities.append(("memory_entries", row[0], text))
+
+    for row in conn.execute(
+        "SELECT id, claim_text, confidence_basis FROM claims"
+    ).fetchall():
+        text = f"{row[1]} {row[2] or ''}"
+        entities.append(("claims", row[0], text))
+
+    for row in conn.execute(
+        "SELECT rowid, trigger_id, description FROM trigger_state"
+    ).fetchall():
+        text = f"{row[1]} {row[2] or ''}"
+        entities.append(("trigger_state", row[0], text))
+
+    for row in conn.execute(
+        "SELECT id, action_type, action_class, description FROM autonomous_actions"
+    ).fetchall():
+        text = f"{row[1]} {row[2]} {row[3] or ''}"
+        entities.append(("autonomous_actions", row[0], text))
+
+    for row in conn.execute(
+        "SELECT rowid, gate_id, sending_agent, receiving_agent, session_name "
+        "FROM active_gates"
+    ).fetchall():
+        text = f"{row[1]} {row[2]} {row[3]} {row[4]}"
+        entities.append(("active_gates", row[0], text))
+
+    # epistemic_flags — quality/validity concerns flagged during sessions
+    for row in conn.execute(
+        "SELECT id, source, flag_text FROM epistemic_flags"
+    ).fetchall():
+        text = f"{row[1]} {row[2]}"
+        entities.append(("epistemic_flags", row[0], text))
+
+    # lessons — transferable patterns with structured frontmatter
+    for row in conn.execute(
+        "SELECT id, title, pattern_type, domain, lesson_text "
+        "FROM lessons"
+    ).fetchall():
+        text = f"{row[1]} {row[2] or ''} {row[3] or ''} {row[4] or ''}"
+        entities.append(("lessons", row[0], text))
+
+    return entities
+
+
+def build_facets(entities: list[tuple]) -> list[tuple]:
+    """Build facet tuples with confidence metadata.
+
+    Returns list of (entity_type, entity_id, facet_type, facet_value,
+                      confidence, keyword_hits_json) tuples.
+    """
+    import json
+    facets = []
+
+    for entity_type, entity_id, text in entities:
+        # PSH subject classification (with confidence + matched keywords)
+        for psh_cat, confidence, hits in classify_psh(text):
+            hits_json = json.dumps(hits, ensure_ascii=False) if hits else None
+            facets.append((entity_type, entity_id, "psh", psh_cat,
+                           confidence, hits_json))
+
+        # schema.org type classification (static per table — confidence 1.0)
+        schema_type = SCHEMA_ORG_TYPES.get(entity_type)
+        if schema_type:
+            facets.append((entity_type, entity_id, "schema_type", schema_type,
+                           1.0, None))
+
+    return facets
+
+
+# ── Discovery ──────────────────────────────────────────────────────────
+
+def discover(conn: sqlite3.Connection) -> None:
+    """Surface candidate PSH L1 and L2 terms from unclassified text.
+
+    Literary warrant (Hulme, 1911): vocabulary terms earn inclusion when
+    enough resources cluster around them. PSH itself grows this way.
+    """
+    entities = collect_entity_text(conn)
+
+    # Find entities that got 'unclassified' only
+    unclassified_text = []
+    for entity_type, entity_id, text in entities:
+        cats = classify_psh_simple(text)
+        if cats == ["unclassified"]:
+            unclassified_text.append(text)
+
+    # Also collect ALL text for L2 candidate detection
+    all_text = [text for _, _, text in entities]
+
+    combined_unclassified = _strip_agent_ids(" ".join(unclassified_text).lower())
+    combined_all = _strip_agent_ids(" ".join(all_text).lower())
+
+    words_unc = re.findall(r"[a-z][a-z0-9-]+", combined_unclassified)
+    words_all = re.findall(r"[a-z][a-z0-9-]+", combined_all)
+
+    stopwords = {
+        "the", "and", "for", "not", "with", "from", "that", "this",
+        "was", "are", "has", "have", "but", "all", "can", "will",
+        "its", "into", "been", "each", "per", "via", "any", "also",
+    }
+
+    def meaningful(term: str) -> bool:
+        parts = term.split()
+        return not all(p in stopwords or len(p) < 3 for p in parts)
+
+    def novel(term: str) -> bool:
+        return not any(kw in term or term in kw for kw in ALL_KNOWN_KEYWORDS)
+
+    # L1 candidates: frequent bigrams in unclassified entities
+    unc_bigrams = Counter()
+    for i in range(len(words_unc) - 1):
+        bg = f"{words_unc[i]} {words_unc[i+1]}"
+        unc_bigrams[bg] += 1
+
+    l1_candidates = {
+        bg: count for bg, count in unc_bigrams.most_common(100)
+        if count >= 3 and novel(bg) and meaningful(bg)
+    }
+
+    # L2 candidates: frequent bigrams in ALL text that could refine existing L1s
+    all_bigrams = Counter()
+    for i in range(len(words_all) - 1):
+        bg = f"{words_all[i]} {words_all[i+1]}"
+        all_bigrams[bg] += 1
+
+    l2_candidates = {}
+    for bg, count in all_bigrams.most_common(200):
+        if count < 5 or not meaningful(bg):
+            continue
+        # Check if this bigram refines an existing L1
+        for cat_name, spec in PSH_CATEGORIES.items():
+            if any(kw in bg for kw in spec["keywords"]):
+                candidate = f"{cat_name}/{bg.replace(' ', '-')}"
+                l2_candidates[candidate] = count
+                break
+
+    # Report
+    print("PSH Facet Discovery Report")
+    print("=" * 60)
+    print(f"\nTotal entities: {len(entities)}")
+    print(f"Unclassified (no L1 match): {len(unclassified_text)}")
+
+    # Current L1 distribution
+    l1_dist = Counter()
+    for _, _, text in entities:
+        for cat in classify_psh_simple(text):
+            l1_dist[cat] += 1
+    print(f"\nActive L1 categories ({len(l1_dist) - (1 if 'unclassified' in l1_dist else 0)}/44 PSH):")
+    print("─" * 50)
+    for cat, count in l1_dist.most_common():
+        code = PSH_CATEGORIES.get(cat, {}).get("code", "—")
+        print(f"  {count:>4}  {cat:<25} {code}")
+
+    # Match unclassified clusters against inactive PSH categories
+    inactive_matches = _match_inactive_categories(conn, unclassified_text, words_unc)
+
+    if l1_candidates:
+        print(f"\nL1 expansion candidates (from unclassified, freq >= 3):")
+        print("─" * 50)
+        for bg, count in sorted(l1_candidates.items(), key=lambda x: -x[1])[:15]:
+            print(f"  {count:>3}x  {bg}")
+
+    if inactive_matches:
+        print(f"\nInactive PSH categories with potential warrant:")
+        print("─" * 50)
+        for cat_name, code, desc, score, matched_words in inactive_matches:
+            print(f"  ⚑ {cat_name} ({code}) — score {score}")
+            print(f"    {desc}")
+            print(f"    Matched: {', '.join(matched_words[:8])}")
+        print("  → Activate by adding keywords to PSH_CATEGORIES + setting active=1")
+    elif l1_candidates:
+        print("  → No inactive PSH categories match — consider project-local (PL-NNN)")
+
+    if l2_candidates:
+        print(f"\nL2 refinement candidates (all text, freq >= 5):")
+        print("─" * 50)
+        for candidate, count in sorted(l2_candidates.items(), key=lambda x: -x[1])[:15]:
+            print(f"  {count:>3}x  {candidate}")
+        print("  → Add as L2 sub-categories when query precision demands it")
+
+    # PSH staleness analysis — categories our data needs that PSH may not cover
+    # PSH last substantially updated ~2015; AI/ML vocabulary absent entirely
+    psh_gaps = []
+    ai_ml_terms = {"agent", "llm", "model", "embedding", "prompt", "token",
+                   "context window", "tool use", "system prompt", "fine-tun",
+                   "alignment", "reinforcement", "rlhf", "anthropic", "claude",
+                   "autonomous", "multi-agent", "agentic"}
+    ai_hits = Counter()
+    for word in words_all:
+        for term in ai_ml_terms:
+            if term in word:
+                ai_hits[term] += 1
+    ai_hits_filtered = {t: c for t, c in ai_hits.items() if c >= 3}
+    if ai_hits_filtered:
+        psh_gaps.append(("AI/ML systems (no PSH category exists)", ai_hits_filtered))
+
+    # Check for terms around "mesh", "distributed", "decentralized" — PSH
+    # has "computer networks" but not modern distributed systems vocabulary
+    distributed_terms = {"mesh", "distributed", "decentralized", "peer-to-peer",
+                         "federation", "gossip", "consensus", "eventual consistency"}
+    dist_hits = Counter()
+    for word in words_all:
+        for term in distributed_terms:
+            if term in word:
+                dist_hits[term] += 1
+    dist_hits_filtered = {t: c for t, c in dist_hits.items() if c >= 2}
+    if dist_hits_filtered:
+        psh_gaps.append(("Distributed systems (PSH12314 too broad)", dist_hits_filtered))
+
+    if psh_gaps:
+        print(f"\nPSH Staleness / Gap Analysis:")
+        print("─" * 50)
+        for gap_label, hits in psh_gaps:
+            hit_str = ", ".join(f"{t}({c})" for t, c in
+                               sorted(hits.items(), key=lambda x: -x[1])[:8])
+            print(f"  ⚑ {gap_label}")
+            print(f"    Evidence: {hit_str}")
+        print("  → Consider project-local categories for domains PSH cannot cover.")
+        print("    Literary warrant justifies extending beyond PSH when the")
+        print("    canonical vocabulary lacks the precision our data demands.")
+
+    print(f"\n{'─' * 60}")
+    print("Literary warrant threshold: L1 = 5+ unclassified entities,")
+    print("L2 = 10+ entities that would benefit from sub-classification.")
+    print("PSH gap threshold: 3+ entity hits on terms absent from PSH.")
+
+
+def _match_inactive_categories(
+    conn: sqlite3.Connection,
+    unclassified_texts: list[str],
+    unclassified_words: list[str],
+) -> list[tuple]:
+    """Match unclassified entity text against inactive PSH category descriptions.
+
+    Returns list of (category_name, code, description, score, matched_words)
+    sorted by score descending. Only categories with score >= 2 returned.
+    """
+    inactive = conn.execute(
+        "SELECT facet_value, code, description FROM facet_vocabulary "
+        "WHERE facet_type = 'psh' AND active = 0"
+    ).fetchall()
+    if not inactive:
+        return []
+
+    combined = " ".join(unclassified_texts).lower()
+    word_freq = Counter(unclassified_words)
+    results = []
+
+    for cat_name, code, description in inactive:
+        # Extract keywords from the category description
+        desc_words = re.findall(r"[a-z][a-z0-9-]+", description.lower())
+        desc_words = [w for w in desc_words if len(w) > 3]
+
+        # Score: how many description words appear in unclassified text?
+        matched = [w for w in desc_words if w in combined and word_freq.get(w, 0) >= 2]
+        # Also check the category name itself
+        if cat_name.replace("-", " ") in combined:
+            matched.append(cat_name)
+
+        score = len(matched)
+        if score >= 2:
+            results.append((cat_name, code, description, score, matched))
+
+    results.sort(key=lambda x: -x[3])
+    return results[:10]
+
+
+# ── Stats ──────────────────────────────────────────────────────────────
+
+def show_stats(conn: sqlite3.Connection) -> None:
+    """Show current facet distribution across both vocabularies."""
+    for facet_type, label in [("psh", "PSH Subject"), ("schema_type", "Schema.org Type")]:
+        rows = conn.execute(
+            "SELECT entity_type, facet_value, COUNT(*) "
+            "FROM universal_facets WHERE facet_type = ? "
+            "GROUP BY entity_type, facet_value "
+            "ORDER BY entity_type, facet_value",
+            (facet_type,)
+        ).fetchall()
+        if not rows:
+            print(f"\nNo {label} facets found. Run without --stats to bootstrap.")
+            continue
+        print(f"\n{label} Facets")
+        print("=" * 60)
+        print(f"{'Entity Type':<25} {'Value':<25} {'Count':>5}")
+        print("─" * 60)
+        for entity_type, value, count in rows:
+            print(f"{entity_type:<25} {value:<25} {count:>5}")
+        total = sum(r[2] for r in rows)
+        print("─" * 60)
+        print(f"{'Total':<25} {'':25} {total:>5}")
+
+    # Also show legacy pje_domain if any exist
+    legacy = conn.execute(
+        "SELECT COUNT(*) FROM universal_facets WHERE facet_type = 'pje_domain'"
+    ).fetchone()[0]
+    if legacy:
+        print(f"\n(Legacy: {legacy} pje_domain facets still present — "
+              f"safe to clean up with: DELETE FROM universal_facets "
+              f"WHERE facet_type = 'pje_domain')")
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Bootstrap PSH + schema.org facets for all state.db entities"
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show classification without writing")
+    parser.add_argument("--stats", action="store_true",
+                        help="Show current facet distribution")
+    parser.add_argument("--discover", action="store_true",
+                        help="Surface candidate L1/L2 PSH terms")
+    parser.add_argument("--clean-legacy", action="store_true",
+                        help="Remove pje_domain facets (replaced by psh)")
+    parser.add_argument("--staleness", action="store_true",
+                        help="Show facet recency and version distribution")
+    args = parser.parse_args()
+
+    if not DB_PATH.exists():
+        print(f"state.db not found at {DB_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = get_connection()
+
+    if args.discover:
+        discover(conn)
+        conn.close()
+        return
+
+    if args.stats:
+        show_stats(conn)
+        conn.close()
+        return
+
+    if args.staleness:
+        _ensure_metadata_columns(conn)
+        # Version distribution
+        rows = conn.execute(
+            "SELECT keyword_set_version, COUNT(*), MIN(computed_at), MAX(computed_at) "
+            "FROM universal_facets WHERE facet_type = 'psh' "
+            "GROUP BY keyword_set_version ORDER BY keyword_set_version"
+        ).fetchall()
+        print("Facet Staleness Report")
+        print("=" * 60)
+        if rows:
+            print(f"\n{'Version':>8}  {'Count':>6}  {'Oldest':>20}  {'Newest':>20}")
+            print("─" * 60)
+            for version, count, oldest, newest in rows:
+                v_str = str(version) if version else "legacy"
+                print(f"  v{v_str:<6} {count:>6}  {oldest or '—':<20}  {newest or '—':<20}")
+        else:
+            print("\nNo PSH facets found.")
+
+        # Low-confidence facets
+        low_conf = conn.execute(
+            "SELECT entity_type, facet_value, COUNT(*), AVG(confidence) "
+            "FROM universal_facets WHERE facet_type = 'psh' AND confidence < 0.15 "
+            "AND facet_value != 'unclassified' "
+            "GROUP BY entity_type, facet_value ORDER BY AVG(confidence)"
+        ).fetchall()
+        if low_conf:
+            print(f"\nLow-confidence facets (confidence < 0.15):")
+            print("─" * 60)
+            for etype, fval, cnt, avg_c in low_conf:
+                print(f"  {etype:<25} {fval:<20} {cnt:>4}  avg={avg_c:.3f}")
+            print("  → These rely on a single keyword match — consider adding keywords")
+
+        # Stale facets (older than current version)
+        stale = conn.execute(
+            "SELECT COUNT(*) FROM universal_facets "
+            "WHERE facet_type = 'psh' AND "
+            "(keyword_set_version IS NULL OR keyword_set_version < ?)",
+            (KEYWORD_SET_VERSION,)
+        ).fetchone()[0]
+        if stale:
+            print(f"\n⚑ {stale} facets computed with older keyword sets — "
+                  f"re-run bootstrap to update to v{KEYWORD_SET_VERSION}")
+
+        conn.close()
+        return
+
+    if args.clean_legacy:
+        deleted = conn.execute(
+            "DELETE FROM universal_facets WHERE facet_type = 'pje_domain'"
+        ).rowcount
+        conn.commit()
+        print(f"Removed {deleted} legacy pje_domain facets.")
+        conn.close()
+        return
+
+    # Collect and classify
+    entities = collect_entity_text(conn)
+    facets = build_facets(entities)
+
+    if args.dry_run:
+        by_type = Counter()
+        confidence_sums = Counter()
+        confidence_counts = Counter()
+        for entity_type, _, facet_type, facet_value, confidence, _ in facets:
+            by_type[(facet_type, facet_value)] += 1
+            if facet_type == "psh":
+                confidence_sums[facet_value] += confidence
+                confidence_counts[facet_value] += 1
+
+        for ft_label, ft_key in [("PSH Subject", "psh"), ("Schema.org Type", "schema_type")]:
+            print(f"\n{ft_label}")
+            if ft_key == "psh":
+                print(f"  {'Category':<25} {'Count':>5}  {'Avg Conf':>8}")
+                print("─" * 45)
+                for (ft, fv), count in sorted(by_type.items()):
+                    if ft == ft_key:
+                        avg_conf = confidence_sums[fv] / confidence_counts[fv] if confidence_counts[fv] else 0
+                        print(f"  {fv:<25} {count:>5}  {avg_conf:>8.3f}")
+            else:
+                print("─" * 45)
+                for (ft, fv), count in sorted(by_type.items()):
+                    if ft == ft_key:
+                        print(f"  {fv:<30} {count:>5}")
+
+        print(f"\nTotal facets: {len(facets)} (keyword set v{KEYWORD_SET_VERSION})")
+        print("Dry run — no changes written.")
+        conn.close()
+        return
+
+    # Ensure metadata columns exist (backward-compatible migration)
+    _ensure_metadata_columns(conn)
+
+    # Write facets with metadata
+    now = conn.execute(
+        "SELECT strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime')"
+    ).fetchone()[0]
+    inserted = 0
+    for entity_type, entity_id, facet_type, facet_value, confidence, hits_json in facets:
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO universal_facets "
+                "(entity_type, entity_id, facet_type, facet_value, "
+                " confidence, keyword_hits, computed_at, keyword_set_version) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (entity_type, entity_id, facet_type, facet_value,
+                 confidence, hits_json, now, KEYWORD_SET_VERSION),
+            )
+            inserted += 1
+        except sqlite3.IntegrityError:
+            pass
+    conn.commit()
+    conn.close()
+
+    print(f"Facets bootstrapped: {inserted} written ({len(facets)} classified)")
+    print(f"  PSH subjects: {sum(1 for f in facets if f[2] == 'psh')}")
+    print(f"  Schema.org types: {sum(1 for f in facets if f[2] == 'schema_type')}")
+    print(f"  Keyword set version: {KEYWORD_SET_VERSION}")
+    print(f"\nVerify: python3 scripts/bootstrap_facets.py --stats")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cross_repo_fetch.py
+++ b/scripts/cross_repo_fetch.py
@@ -17,12 +17,20 @@ import os
 import sqlite3
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 REGISTRY_PATH = PROJECT_ROOT / "transport" / "agent-registry.json"
+REGISTRY_LOCAL_PATH = PROJECT_ROOT / "transport" / "agent-registry.local.json"
 DB_PATH = PROJECT_ROOT / "state.db"
+
+# Adaptive sync frequency — peers classified by recency of last exchange.
+# Active: unprocessed messages or exchange within WARM_THRESHOLD → always fetch.
+# Warm: exchange within COLD_THRESHOLD → fetch (default cron handles this).
+# Cold: no exchange beyond COLD_THRESHOLD → skip fetch unless --force.
+WARM_THRESHOLD_HOURS = 1
+COLD_THRESHOLD_HOURS = 24
 
 
 def run_git(*args: str) -> tuple[int, str]:
@@ -82,30 +90,147 @@ def get_indexed_filenames(db_path: Path, session_name: str) -> set[str]:
         return set()
 
 
+def classify_peer_activity(agent_id: str, agent_config: dict) -> str:
+    """Classify a peer as 'active', 'warm', or 'cold' based on state.db.
+
+    Active: unprocessed inbound messages exist, or active gates involve this agent.
+    Warm: last exchange within COLD_THRESHOLD_HOURS.
+    Cold: no exchange beyond COLD_THRESHOLD_HOURS (or no exchange at all).
+    """
+    if not DB_PATH.exists():
+        return "active"  # No DB = can't classify, assume active
+
+    # Build list of agent ID patterns to match (agent may appear as
+    # psq-agent, psq-sub-agent, etc. in from_agent/to_agent columns)
+    agent_patterns = [agent_id]
+    message_prefix = agent_config.get("message_prefix", "")
+    # Extract the agent name from message_prefix (strip leading "from-" and trailing "-")
+    if message_prefix.startswith("from-"):
+        extracted = message_prefix[5:].rstrip("-")
+        if extracted and extracted != agent_id:
+            agent_patterns.append(extracted)
+
+    try:
+        conn = sqlite3.connect(str(DB_PATH))
+
+        # Check for unprocessed messages from this agent
+        for pattern in agent_patterns:
+            unprocessed = conn.execute(
+                "SELECT COUNT(*) FROM transport_messages "
+                "WHERE from_agent = ? AND processed = FALSE",
+                (pattern,)
+            ).fetchone()[0]
+            if unprocessed > 0:
+                conn.close()
+                return "active"
+
+        # Check for active gates involving this agent
+        try:
+            for pattern in agent_patterns:
+                active_gates = conn.execute(
+                    "SELECT COUNT(*) FROM active_gates "
+                    "WHERE status = 'waiting' "
+                    "AND (sending_agent = ? OR receiving_agent = ?)",
+                    (pattern, pattern)
+                ).fetchone()[0]
+                if active_gates > 0:
+                    conn.close()
+                    return "active"
+        except sqlite3.OperationalError:
+            pass  # active_gates table may not exist
+
+        # Check recency of last exchange — match any agent pattern
+        placeholders = " OR ".join(
+            ["from_agent = ? OR to_agent = ?"] * len(agent_patterns)
+        )
+        params = []
+        for p in agent_patterns:
+            params.extend([p, p])
+        row = conn.execute(
+            f"SELECT MAX(timestamp) FROM transport_messages WHERE {placeholders}",
+            params
+        ).fetchone()
+        conn.close()
+
+        if row[0] is None:
+            return "cold"
+
+        # Parse the timestamp — handle various ISO 8601 formats
+        last_ts = row[0]
+        try:
+            # Try with timezone offset (e.g., 2026-03-10T10:52:35-05:00)
+            last_dt = datetime.fromisoformat(last_ts)
+            now = datetime.now(last_dt.tzinfo) if last_dt.tzinfo else datetime.now()
+        except (ValueError, TypeError):
+            return "warm"  # Can't parse = assume warm (don't skip)
+
+        elapsed = now - last_dt
+        if elapsed < timedelta(hours=COLD_THRESHOLD_HOURS):
+            return "warm"
+        return "cold"
+
+    except sqlite3.OperationalError:
+        return "active"  # DB error = can't classify, assume active
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base (override wins on conflicts)."""
+    merged = base.copy()
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def load_registry() -> dict:
-    """Load agent-registry.json."""
+    """Load agent registry, merging local overrides if present."""
     with open(REGISTRY_PATH) as f:
-        return json.load(f)
+        registry = json.load(f)
+    if REGISTRY_LOCAL_PATH.exists():
+        try:
+            with open(REGISTRY_LOCAL_PATH) as f:
+                local = json.load(f)
+            registry = _deep_merge(registry, local)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return registry
 
 
-def scan_agent(agent_id: str, agent_config: dict, index: bool = False) -> dict:
+def scan_agent(agent_id: str, agent_config: dict, index: bool = False,
+               force: bool = False) -> dict:
     """Scan a cross-repo-fetch agent for new messages.
 
-    Returns a dict with scan results.
+    Returns a dict with scan results. Skips cold peers unless force=True.
     """
     remote_name = agent_config.get("remote_name")
     if not remote_name:
         return {"agent_id": agent_id, "error": "no remote_name configured"}
 
+    message_prefix = agent_config.get("message_prefix", "")
+
+    # Adaptive sync: classify peer activity and skip cold peers
+    activity_tier = classify_peer_activity(agent_id, agent_config)
+
     result = {
         "agent_id": agent_id,
         "remote_name": remote_name,
+        "activity_tier": activity_tier,
         "fetch_ok": False,
         "manifest_found": False,
         "sessions_scanned": [],
         "new_messages": [],
         "errors": [],
     }
+
+    if activity_tier == "cold" and not force:
+        result["skipped"] = True
+        result["skip_reason"] = (
+            f"cold peer — no exchange within {COLD_THRESHOLD_HOURS}h, "
+            "no unprocessed messages, no active gates"
+        )
+        return result
 
     # Fetch the remote
     if not fetch_remote(remote_name):
@@ -233,6 +358,8 @@ def main():
                         help="Index new messages in state.db")
     parser.add_argument("--json", action="store_true",
                         help="Output as JSON")
+    parser.add_argument("--force", action="store_true",
+                        help="Fetch all peers regardless of activity tier")
     args = parser.parse_args()
 
     registry = load_registry()
@@ -244,7 +371,8 @@ def main():
             continue
         if args.agent and agent_id != args.agent:
             continue
-        result = scan_agent(agent_id, config, index=args.index)
+        result = scan_agent(agent_id, config, index=args.index,
+                            force=args.force)
         results.append(result)
 
     if args.json:
@@ -254,7 +382,14 @@ def main():
     # Human-readable output
     for r in results:
         print(f"\n{'─' * 60}")
-        print(f"Agent: {r['agent_id']} (remote: {r.get('remote_name', '?')})")
+        tier = r.get('activity_tier', '?')
+        tier_label = {"active": "ACTIVE", "warm": "warm", "cold": "cold"}.get(tier, tier)
+        print(f"Agent: {r['agent_id']} (remote: {r.get('remote_name', '?')}) [{tier_label}]")
+
+        if r.get("skipped"):
+            print(f"  SKIPPED: {r.get('skip_reason', 'cold peer')}")
+            continue
+
         print(f"  Fetch: {'✓' if r.get('fetch_ok') else '✗'}")
         print(f"  MANIFEST: {'✓ found' if r.get('manifest_found') else '✗ not found'}")
 

--- a/scripts/mesh-state-export.py
+++ b/scripts/mesh-state-export.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""mesh-state-export.py — Export operational state for cross-machine visibility.
+
+Dumps a lean JSON snapshot of trust budget, recent autonomous actions,
+facet distribution, and transport health. Committed by autonomous-sync.sh
+alongside heartbeat — peers read it via `git show remote/main:path`.
+
+The export replaces nothing — it provides a queryable view of operational
+state without requiring SSH access or real-time connectivity.
+
+Usage:
+    python3 scripts/mesh-state-export.py                    # write to transport/
+    python3 scripts/mesh-state-export.py --stdout           # print to stdout
+    python3 scripts/mesh-state-export.py --path /custom/dir # custom output dir
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_ROOT / "state.db"
+IDENTITY_PATH = PROJECT_ROOT / ".agent-identity.json"
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "transport" / "sessions" / "local-coordination"
+
+
+def get_agent_id() -> str:
+    """Read agent ID from identity file or default."""
+    if IDENTITY_PATH.exists():
+        try:
+            return json.loads(IDENTITY_PATH.read_text())["agent_id"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return "unknown-agent"
+
+
+def query(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> list[dict]:
+    """Run a query and return list of dicts."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params: tuple = (), default=0):
+    """Run a query and return a single scalar."""
+    row = conn.execute(sql, params).fetchone()
+    return row[0] if row else default
+
+
+def export_state(conn: sqlite3.Connection, agent_id: str) -> dict:
+    """Build the operational state snapshot."""
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+
+    # Trust budget
+    budget_rows = query(
+        conn,
+        "SELECT agent_id, budget_max, budget_current, shadow_mode, "
+        "consecutive_blocks, last_action, min_action_interval "
+        "FROM trust_budget WHERE agent_id = ?",
+        (agent_id,)
+    )
+    budget = budget_rows[0] if budget_rows else {}
+
+    # Recent autonomous actions (last 10)
+    actions = query(
+        conn,
+        "SELECT action_type, evaluator_result, evaluator_tier, "
+        "budget_before, budget_after, created_at "
+        "FROM autonomous_actions ORDER BY created_at DESC LIMIT 10"
+    )
+
+    # Transport summary
+    total_messages = scalar(conn, "SELECT COUNT(*) FROM transport_messages")
+    unprocessed = scalar(
+        conn, "SELECT COUNT(*) FROM transport_messages WHERE processed = FALSE"
+    )
+    active_gates = scalar(
+        conn, "SELECT COUNT(*) FROM active_gates WHERE status = 'waiting'"
+    )
+
+    # PSH facet summary (if universal_facets exists)
+    psh_summary = {}
+    try:
+        for row in query(
+            conn,
+            "SELECT facet_value, COUNT(*) as count "
+            "FROM universal_facets WHERE facet_type = 'psh' "
+            "GROUP BY facet_value ORDER BY count DESC"
+        ):
+            psh_summary[row["facet_value"]] = row["count"]
+    except sqlite3.OperationalError:
+        pass
+
+    # Schema version
+    schema_ver = scalar(conn, "SELECT MAX(version) FROM schema_version")
+
+    # Epistemic debt
+    epistemic_flags = scalar(
+        conn, "SELECT COUNT(*) FROM epistemic_flags WHERE resolved = FALSE"
+    )
+
+    return {
+        "schema": "mesh-state/v1",
+        "timestamp": now,
+        "agent_id": agent_id,
+        "trust_budget": budget,
+        "recent_actions": actions,
+        "transport": {
+            "total_messages": total_messages,
+            "unprocessed": unprocessed,
+            "active_gates": active_gates,
+        },
+        "psh_facets": psh_summary,
+        "schema_version": schema_ver,
+        "epistemic_flags_unresolved": epistemic_flags,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export operational state for cross-machine mesh visibility"
+    )
+    parser.add_argument("--stdout", action="store_true",
+                        help="Print to stdout instead of writing file")
+    parser.add_argument("--path", type=str,
+                        help="Custom output directory")
+    args = parser.parse_args()
+
+    if not DB_PATH.exists():
+        print(f"state.db not found at {DB_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.execute("PRAGMA journal_mode = WAL")
+    agent_id = get_agent_id()
+    state = export_state(conn, agent_id)
+    conn.close()
+
+    output = json.dumps(state, indent=2, default=str)
+
+    if args.stdout:
+        print(output)
+        return
+
+    output_dir = Path(args.path) if args.path else DEFAULT_OUTPUT_DIR
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / f"mesh-state-{agent_id}.json"
+    output_file.write_text(output + "\n")
+    print(f"exported: {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mesh-status.py
+++ b/scripts/mesh-status.py
@@ -1,0 +1,1086 @@
+#!/usr/bin/env python3
+"""mesh-status.py — Real-time autonomous mesh status dashboard.
+
+Serves a single HTML page that auto-refreshes every 30 seconds, showing
+the current state of the agent mesh: trust budget, peer activity, transport
+queue, active gates, recent actions, and sync health.
+
+Usage:
+    python3 scripts/mesh-status.py              # serve on :8077
+    python3 scripts/mesh-status.py --port 9000  # custom port
+    python3 scripts/mesh-status.py --json       # dump status as JSON (no server)
+
+Requires: Python 3.10+ (stdlib only — http.server, sqlite3, json)
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_ROOT / "state.db"
+REGISTRY_PATH = PROJECT_ROOT / "transport" / "agent-registry.json"
+REGISTRY_LOCAL_PATH = PROJECT_ROOT / "transport" / "agent-registry.local.json"
+IDENTITY_PATH = PROJECT_ROOT / ".agent-identity.json"
+
+COLD_THRESHOLD_HOURS = 24
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base (override wins on conflicts)."""
+    merged = base.copy()
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _load_registry() -> dict:
+    """Load agent registry, merging local overrides if present."""
+    if not REGISTRY_PATH.exists():
+        return {}
+    try:
+        reg = json.loads(REGISTRY_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if REGISTRY_LOCAL_PATH.exists():
+        try:
+            local = json.loads(REGISTRY_LOCAL_PATH.read_text())
+            reg = _deep_merge(reg, local)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return reg
+
+
+def get_agent_id() -> str:
+    """Read agent ID from identity file or default."""
+    if IDENTITY_PATH.exists():
+        try:
+            return json.loads(IDENTITY_PATH.read_text())["agent_id"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return "psychology-agent"
+
+
+def query_db(sql: str, params: tuple = ()) -> list[dict]:
+    """Run a query and return list of dicts."""
+    if not DB_PATH.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(DB_PATH))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+        result = [dict(r) for r in rows]
+        conn.close()
+        return result
+    except sqlite3.OperationalError:
+        return []
+
+
+def scalar(sql: str, params: tuple = (), default=0):
+    """Run a query and return a single scalar value."""
+    if not DB_PATH.exists():
+        return default
+    try:
+        conn = sqlite3.connect(str(DB_PATH))
+        row = conn.execute(sql, params).fetchone()
+        conn.close()
+        return row[0] if row and row[0] is not None else default
+    except sqlite3.OperationalError:
+        return default
+
+
+def _collect_schedule(agent_id: str) -> dict:
+    """Collect sync schedule from cron, log file, and state.db."""
+    import re
+    import subprocess
+
+    schedule = {
+        "cron_entry": None,
+        "cron_interval_min": None,
+        "last_sync": None,
+        "next_expected": None,
+        "min_action_interval_sec": None,
+        "lock_file": None,
+        "lock_active": False,
+    }
+
+    # Parse cron for autonomous-sync entries
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"], capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if "autonomous-sync" in line and not line.startswith("#"):
+                    schedule["cron_entry"] = line.strip()
+                    # Extract interval from */N pattern
+                    m = re.match(r"\*/(\d+)", line.strip())
+                    if m:
+                        schedule["cron_interval_min"] = int(m.group(1))
+                    # Check for hourly pattern "0 * * * *"
+                    elif line.strip().startswith("0 "):
+                        schedule["cron_interval_min"] = 60
+                    break
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    # min_action_interval from trust_budget
+    row = query_db(
+        "SELECT min_action_interval FROM trust_budget WHERE agent_id = ?",
+        (agent_id,)
+    )
+    if row:
+        schedule["min_action_interval_sec"] = row[0].get("min_action_interval")
+
+    # Last autonomous action timestamp
+    last = query_db(
+        "SELECT MAX(created_at) as last_action FROM autonomous_actions"
+    )
+    if last and last[0].get("last_action"):
+        schedule["last_sync"] = last[0]["last_action"]
+
+    # Last sync from log file (most recent line with timestamp)
+    log_path = Path("/tmp") / f"autonomous-sync-{agent_id}.log"
+    if log_path.exists():
+        try:
+            # Read last 20 lines for recency
+            lines = log_path.read_text().splitlines()[-20:]
+            for line in reversed(lines):
+                m = re.match(r"\[(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})", line)
+                if m:
+                    schedule["last_sync"] = m.group(1)
+                    break
+        except OSError:
+            pass
+
+    # Compute next expected from last_sync + cron interval
+    if schedule["last_sync"] and schedule["cron_interval_min"]:
+        try:
+            last_dt = datetime.fromisoformat(schedule["last_sync"])
+            next_dt = last_dt + timedelta(minutes=schedule["cron_interval_min"])
+            schedule["next_expected"] = next_dt.strftime("%Y-%m-%dT%H:%M:%S")
+        except (ValueError, TypeError):
+            pass
+
+    # Check lock file
+    lock_path = Path("/tmp") / f"autonomous-sync-{agent_id}.lock"
+    schedule["lock_file"] = str(lock_path)
+    if lock_path.exists():
+        try:
+            pid = int(lock_path.read_text().strip())
+            # Check if PID is alive
+            import os
+            try:
+                os.kill(pid, 0)
+                schedule["lock_active"] = True
+                schedule["lock_pid"] = pid
+            except OSError:
+                schedule["lock_active"] = False
+                schedule["lock_pid"] = pid
+                schedule["lock_stale"] = True
+        except (ValueError, OSError):
+            pass
+
+    return schedule
+
+
+def _collect_remote_states(registry_agents: dict) -> list[dict]:
+    """Read mesh-state JSON snapshots from remote repos via git show."""
+    import subprocess
+
+    results = []
+
+    # Also check local-coordination for local mesh-state files
+    local_dir = PROJECT_ROOT / "transport" / "sessions" / "local-coordination"
+    if local_dir.exists():
+        for f in local_dir.glob("mesh-state-*.json"):
+            try:
+                data = json.loads(f.read_text())
+                data["_source"] = f"local ({f.name})"
+                results.append(data)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # Read from registered remotes with cross-repo-fetch transport
+    reg = _load_registry()
+    if not reg:
+        return results
+
+    for agent_id, cfg in reg.get("agents", {}).items():
+        if cfg.get("transport") != "cross-repo-fetch":
+            continue
+        remote_name = cfg.get("remote_name")
+        if not remote_name:
+            continue
+
+        # Try git show for the mesh-state file on the remote
+        mesh_path = f"transport/sessions/local-coordination/mesh-state-{agent_id}.json"
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(PROJECT_ROOT), "show",
+                 f"{remote_name}/main:{mesh_path}"],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                data = json.loads(result.stdout)
+                data["_source"] = f"git show {remote_name}/main"
+                results.append(data)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+            pass
+
+    return results
+
+
+def collect_status() -> dict:
+    """Collect all mesh status data from state.db."""
+    agent_id = get_agent_id()
+    now_iso = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+
+    # Trust budget
+    budget = query_db(
+        "SELECT * FROM trust_budget WHERE agent_id = ?", (agent_id,)
+    )
+    budget_row = budget[0] if budget else {}
+
+    # Active gates
+    gates = query_db(
+        "SELECT * FROM active_gates WHERE status = 'waiting' ORDER BY created_at"
+    )
+
+    # Unprocessed messages
+    unprocessed = query_db(
+        "SELECT session_name, filename, turn, from_agent, message_type, "
+        "timestamp, subject FROM transport_messages "
+        "WHERE processed = FALSE ORDER BY timestamp DESC"
+    )
+
+    # Recent messages (last 20)
+    recent = query_db(
+        "SELECT session_name, filename, turn, from_agent, to_agent, "
+        "message_type, timestamp, processed, subject "
+        "FROM transport_messages ORDER BY timestamp DESC LIMIT 20"
+    )
+
+    # Recent autonomous actions (last 10)
+    actions = query_db(
+        "SELECT action_type, action_class, evaluator_tier, evaluator_result, "
+        "description, budget_before, budget_after, created_at "
+        "FROM autonomous_actions ORDER BY created_at DESC LIMIT 10"
+    )
+
+    # Peer activity summary
+    peers = query_db(
+        "SELECT from_agent, MAX(timestamp) as last_seen, COUNT(*) as total_messages "
+        "FROM transport_messages WHERE from_agent != ? "
+        "GROUP BY from_agent ORDER BY last_seen DESC",
+        (agent_id,)
+    )
+
+    # Message counts by agent
+    msg_counts = query_db(
+        "SELECT from_agent, COUNT(*) as sent, "
+        "SUM(CASE WHEN processed = FALSE THEN 1 ELSE 0 END) as pending "
+        "FROM transport_messages GROUP BY from_agent ORDER BY sent DESC"
+    )
+
+    # Epistemic debt
+    total_flags = scalar(
+        "SELECT COUNT(*) FROM epistemic_flags WHERE resolved = FALSE"
+    )
+
+    # Schema version
+    schema_ver = scalar("SELECT MAX(version) FROM schema_version")
+
+    # Transport totals
+    total_messages = scalar("SELECT COUNT(*) FROM transport_messages")
+    total_sessions = scalar("SELECT COUNT(DISTINCT session_name) FROM transport_messages")
+
+    # Heartbeat (check for recent heartbeat file)
+    heartbeat_path = PROJECT_ROOT / "transport" / "heartbeat.json"
+    heartbeat_info = {}
+    if heartbeat_path.exists():
+        try:
+            heartbeat_info = json.loads(heartbeat_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Registry info
+    registry_agents = {}
+    reg = _load_registry()
+    for aid, cfg in reg.get("agents", {}).items():
+        registry_agents[aid] = {
+            "role": cfg.get("role"),
+            "transport": cfg.get("transport"),
+            "autonomous": cfg.get("autonomous", False),
+            "always_consider": cfg.get("always_consider", False),
+        }
+
+    # Sync schedule — cron entry + last/next sync times
+    schedule = _collect_schedule(agent_id)
+
+    # Facet vocabulary (semiotics tab)
+    facet_vocab = query_db(
+        "SELECT facet_type, facet_value, code, source, description, "
+        "entity_scope, active, keyword_count FROM facet_vocabulary "
+        "ORDER BY facet_type, active DESC, facet_value"
+    )
+
+    # Facet distribution: entity counts per PSH category
+    psh_dist = query_db(
+        "SELECT facet_value, COUNT(*) as entity_count, "
+        "ROUND(AVG(confidence), 3) as avg_confidence, "
+        "MIN(confidence) as min_confidence, "
+        "MAX(confidence) as max_confidence "
+        "FROM universal_facets WHERE facet_type = 'psh' "
+        "GROUP BY facet_value ORDER BY entity_count DESC"
+    )
+
+    # Schema.org type distribution
+    schema_dist = query_db(
+        "SELECT facet_value, COUNT(*) as entity_count "
+        "FROM universal_facets WHERE facet_type = 'schema_type' "
+        "GROUP BY facet_value ORDER BY entity_count DESC"
+    )
+
+    # Keyword set version info
+    version_dist = query_db(
+        "SELECT keyword_set_version, COUNT(*) as facet_count, "
+        "MIN(computed_at) as oldest, MAX(computed_at) as newest "
+        "FROM universal_facets WHERE facet_type = 'psh' "
+        "GROUP BY keyword_set_version ORDER BY keyword_set_version"
+    )
+
+    # Low confidence facets (potential misclassifications)
+    low_conf_count = scalar(
+        "SELECT COUNT(*) FROM universal_facets "
+        "WHERE facet_type = 'psh' AND confidence < 0.05 "
+        "AND facet_value != 'unclassified'"
+    )
+
+    # Remote peer state (via git show on mesh-state exports)
+    remote_states = _collect_remote_states(registry_agents)
+
+    return {
+        "agent_id": agent_id,
+        "collected_at": now_iso,
+        "db_path": str(DB_PATH),
+        "db_exists": DB_PATH.exists(),
+        "schema_version": schema_ver,
+        "trust_budget": budget_row,
+        "active_gates": gates,
+        "unprocessed_messages": unprocessed,
+        "recent_messages": recent,
+        "recent_actions": actions,
+        "peers": peers,
+        "message_counts": msg_counts,
+        "registry_agents": registry_agents,
+        "remote_states": remote_states,
+        "totals": {
+            "messages": total_messages,
+            "sessions": total_sessions,
+            "unprocessed": len(unprocessed),
+            "active_gates": len(gates),
+            "epistemic_flags_unresolved": total_flags,
+        },
+        "heartbeat": heartbeat_info,
+        "schedule": schedule,
+        "semiotics": {
+            "vocabulary": facet_vocab,
+            "psh_distribution": psh_dist,
+            "schema_distribution": schema_dist,
+            "version_distribution": version_dist,
+            "low_confidence_count": low_conf_count,
+        },
+    }
+
+
+# ── HTML Template ────────────────────────────────────────────────────────
+
+def render_html(status: dict) -> str:
+    """Render status data as an HTML dashboard."""
+    budget = status.get("trust_budget", {})
+    totals = status.get("totals", {})
+    schedule = status.get("schedule", {})
+
+    budget_current = budget.get("budget_current", "?")
+    budget_max = budget.get("budget_max", "?")
+    last_action = budget.get("last_action", "never")
+    consecutive_blocks = budget.get("consecutive_blocks", 0)
+    shadow_mode = budget.get("shadow_mode", 0)
+
+    # Budget bar
+    if isinstance(budget_current, (int, float)) and isinstance(budget_max, (int, float)) and budget_max > 0:
+        budget_pct = int((budget_current / budget_max) * 100)
+        if budget_pct > 60:
+            budget_color = "#4caf50"
+        elif budget_pct > 30:
+            budget_color = "#ff9800"
+        else:
+            budget_color = "#f44336"
+    else:
+        budget_pct = 0
+        budget_color = "#666"
+
+    # Peers HTML
+    peers_html = ""
+    for peer in status.get("peers", []):
+        last_seen = peer.get("last_seen", "unknown")
+        try:
+            dt = datetime.fromisoformat(last_seen)
+            elapsed = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+            delta = elapsed - dt
+            hours = delta.total_seconds() / 3600
+            if hours < 1:
+                tier_class = "tier-active"
+                tier_label = "ACTIVE"
+            elif hours < COLD_THRESHOLD_HOURS:
+                tier_class = "tier-warm"
+                tier_label = "warm"
+            else:
+                tier_class = "tier-cold"
+                tier_label = "cold"
+            age = f"{hours:.1f}h ago"
+        except (ValueError, TypeError):
+            tier_class = "tier-cold"
+            tier_label = "?"
+            age = last_seen
+
+        reg = status.get("registry_agents", {}).get(peer["from_agent"], {})
+        role = reg.get("role", "")
+        autonomous = "🤖" if reg.get("autonomous") else ""
+
+        peers_html += f"""
+        <tr>
+            <td>{peer['from_agent']} {autonomous}</td>
+            <td>{role}</td>
+            <td><span class="{tier_class}">{tier_label}</span></td>
+            <td>{age}</td>
+            <td>{peer['total_messages']}</td>
+        </tr>"""
+
+    # Unprocessed messages HTML — accordion with full details
+    unprocessed_html = ""
+    for idx, msg in enumerate(status.get("unprocessed_messages", [])):
+        uid = f"unproc-{idx}"
+        subject = msg.get('subject', '') or '(no subject)'
+        unprocessed_html += f"""
+        <tr class="accordion-header" onclick="toggleRow('{uid}')">
+            <td>▸</td>
+            <td>{msg.get('from_agent', '?')}</td>
+            <td>{msg.get('session_name', '?')}</td>
+            <td>{msg.get('turn', '?')}</td>
+            <td>{msg.get('message_type', '?')}</td>
+            <td>{msg.get('timestamp', '?')}</td>
+        </tr>
+        <tr id="{uid}" class="accordion-detail" style="display:none">
+            <td colspan="6">
+                <div class="detail-grid">
+                    <div><span class="detail-label">Subject:</span> {subject}</div>
+                    <div><span class="detail-label">Filename:</span> {msg.get('filename', '?')}</div>
+                    <div><span class="detail-label">Session:</span> {msg.get('session_name', '?')}</div>
+                    <div><span class="detail-label">Turn:</span> {msg.get('turn', '?')}</div>
+                    <div><span class="detail-label">From:</span> {msg.get('from_agent', '?')}</div>
+                    <div><span class="detail-label">Type:</span> {msg.get('message_type', '?')}</div>
+                    <div><span class="detail-label">Timestamp:</span> {msg.get('timestamp', '?')}</div>
+                </div>
+            </td>
+        </tr>"""
+
+    if not unprocessed_html:
+        unprocessed_html = '<tr><td colspan="6" class="empty">No unprocessed messages</td></tr>'
+
+    # Active gates HTML
+    gates_html = ""
+    for gate in status.get("active_gates", []):
+        gates_html += f"""
+        <tr>
+            <td>{gate.get('gate_id', '?')}</td>
+            <td>{gate.get('receiving_agent', '?')}</td>
+            <td>{gate.get('session_name', '?')}</td>
+            <td>{gate.get('timeout_at', '?')}</td>
+            <td>{gate.get('fallback_action', '?')}</td>
+        </tr>"""
+
+    if not gates_html:
+        gates_html = '<tr><td colspan="5" class="empty">No active gates</td></tr>'
+
+    # Recent messages HTML — accordion with full details
+    recent_html = ""
+    for idx, msg in enumerate(status.get("recent_messages", [])):
+        rid = f"recent-{idx}"
+        processed_icon = "✓" if msg.get("processed") else "○"
+        processed_class = "processed" if msg.get("processed") else "pending"
+        subject = msg.get('subject', '') or '(no subject)'
+        recent_html += f"""
+        <tr class="{processed_class} accordion-header" onclick="toggleRow('{rid}')">
+            <td>▸</td>
+            <td>{processed_icon}</td>
+            <td>{msg.get('from_agent', '?')}</td>
+            <td>{msg.get('to_agent', '?')}</td>
+            <td>{msg.get('session_name', '?')}</td>
+            <td>{msg.get('turn', '?')}</td>
+            <td>{msg.get('message_type', '?')}</td>
+        </tr>
+        <tr id="{rid}" class="accordion-detail" style="display:none">
+            <td colspan="7">
+                <div class="detail-grid">
+                    <div><span class="detail-label">Subject:</span> {subject}</div>
+                    <div><span class="detail-label">Filename:</span> {msg.get('filename', '?')}</div>
+                    <div><span class="detail-label">From:</span> {msg.get('from_agent', '?')}</div>
+                    <div><span class="detail-label">To:</span> {msg.get('to_agent', '?')}</div>
+                    <div><span class="detail-label">Session:</span> {msg.get('session_name', '?')}</div>
+                    <div><span class="detail-label">Turn:</span> {msg.get('turn', '?')}</div>
+                    <div><span class="detail-label">Type:</span> {msg.get('message_type', '?')}</div>
+                    <div><span class="detail-label">Timestamp:</span> {msg.get('timestamp', '?')}</div>
+                    <div><span class="detail-label">Processed:</span> {'Yes' if msg.get('processed') else 'No'}</div>
+                </div>
+            </td>
+        </tr>"""
+
+    # Recent actions HTML — accordion with full details
+    actions_html = ""
+    for idx, action in enumerate(status.get("recent_actions", [])):
+        aid = f"action-{idx}"
+        result = action.get("evaluator_result", "?")
+        result_class = "result-approved" if result == "approved" else "result-blocked"
+        cost = action.get("budget_before", 0) - action.get("budget_after", 0)
+        description = action.get('description', '') or ''
+        actions_html += f"""
+        <tr class="accordion-header" onclick="toggleRow('{aid}')">
+            <td>▸</td>
+            <td>{action.get('action_type', '?')}</td>
+            <td><span class="{result_class}">{result}</span></td>
+            <td>T{action.get('evaluator_tier', '?')}</td>
+            <td>{cost}</td>
+            <td>{action.get('created_at', '?')}</td>
+        </tr>
+        <tr id="{aid}" class="accordion-detail" style="display:none">
+            <td colspan="6">
+                <div class="detail-grid">
+                    <div><span class="detail-label">Description:</span> {description}</div>
+                    <div><span class="detail-label">Action type:</span> {action.get('action_type', '?')}</div>
+                    <div><span class="detail-label">Action class:</span> {action.get('action_class', '?')}</div>
+                    <div><span class="detail-label">Evaluator tier:</span> T{action.get('evaluator_tier', '?')}</div>
+                    <div><span class="detail-label">Result:</span> {result}</div>
+                    <div><span class="detail-label">Budget before:</span> {action.get('budget_before', '?')}</div>
+                    <div><span class="detail-label">Budget after:</span> {action.get('budget_after', '?')}</div>
+                    <div><span class="detail-label">Cost:</span> {cost}</div>
+                    <div><span class="detail-label">Time:</span> {action.get('created_at', '?')}</div>
+                </div>
+            </td>
+        </tr>"""
+
+    if not actions_html:
+        actions_html = '<tr><td colspan="6" class="empty">No autonomous actions recorded</td></tr>'
+
+    # ── Remote peer states ─────────────────────────────────────────────
+    remote_html = ""
+    for rs in status.get("remote_states", []):
+        agent = rs.get("agent_id", "unknown")
+        ts = rs.get("timestamp", "?")
+        source = rs.get("_source", "?")
+        trust = rs.get("trust_budget", {})
+        transport = rs.get("transport", {})
+        budget_str = f"{trust.get('budget_current', '?')}/{trust.get('budget_max', '?')}" if trust else "—"
+        unprocessed = transport.get("unprocessed", 0)
+        active_gates = transport.get("active_gates", 0)
+        total_msgs = transport.get("total_messages", 0)
+        schema_ver = rs.get("schema_version", "?")
+        epi_flags = rs.get("epistemic_flags_unresolved", 0)
+
+        # PSH summary
+        psh = rs.get("psh_facets", {})
+        psh_str = ", ".join(f"{k}: {v}" for k, v in list(psh.items())[:5]) if psh else "—"
+
+        remote_html += f"""
+        <tr>
+            <td>{agent}</td>
+            <td>{budget_str}</td>
+            <td>{unprocessed}</td>
+            <td>{active_gates}</td>
+            <td>{total_msgs}</td>
+            <td>{epi_flags}</td>
+            <td>v{schema_ver}</td>
+            <td>{ts}</td>
+        </tr>
+        <tr><td colspan="8" style="font-size:0.8em; color:#8b949e; padding:2px 12px 8px">
+            Source: {source} · PSH: {psh_str}
+        </td></tr>"""
+
+    if not remote_html:
+        remote_html = '<tr><td colspan="8" class="empty">No remote state snapshots available</td></tr>'
+
+    # ── Semiotics tab ──────────────────────────────────────────────────
+    semiotics = status.get("semiotics", {})
+    psh_dist = semiotics.get("psh_distribution", [])
+    schema_dist = semiotics.get("schema_distribution", [])
+    vocab = semiotics.get("vocabulary", [])
+    version_dist = semiotics.get("version_distribution", [])
+    low_conf = semiotics.get("low_confidence_count", 0)
+
+    # Max entity count for bar scaling
+    max_psh_count = max((d.get("entity_count", 0) for d in psh_dist), default=1)
+
+    # PSH distribution with bars
+    psh_rows = ""
+    for d in psh_dist:
+        cat = d.get("facet_value", "?")
+        count = d.get("entity_count", 0)
+        avg_conf = d.get("avg_confidence", 0) or 0
+        bar_pct = int((count / max_psh_count) * 100) if max_psh_count else 0
+
+        # Confidence color
+        if avg_conf < 0.05:
+            conf_class = "conf-low"
+        elif avg_conf < 0.12:
+            conf_class = "conf-mid"
+        else:
+            conf_class = "conf-high"
+
+        # Find code from vocab
+        code = ""
+        for v in vocab:
+            if v.get("facet_value") == cat and v.get("facet_type") == "psh":
+                code = v.get("code", "")
+                break
+
+        psh_rows += f"""
+        <tr>
+            <td>{cat}</td>
+            <td style="color:#6e7681">{code}</td>
+            <td style="text-align:right">{count}</td>
+            <td class="{conf_class}" style="text-align:right">{avg_conf:.3f}</td>
+            <td style="width:30%"><div class="psh-bar"><div class="psh-fill" style="width:{bar_pct}%;background:#58a6ff"></div></div></td>
+        </tr>"""
+
+    # Schema.org distribution
+    schema_rows = ""
+    for d in schema_dist:
+        schema_rows += f"""
+        <tr>
+            <td>{d.get('facet_value', '?')}</td>
+            <td style="text-align:right">{d.get('entity_count', 0)}</td>
+        </tr>"""
+
+    # Vocabulary registry — active then inactive
+    active_vocab = [v for v in vocab if v.get("active")]
+    inactive_vocab = [v for v in vocab if not v.get("active") and v.get("facet_type") == "psh"]
+
+    active_rows = ""
+    for v in active_vocab:
+        ft = v.get("facet_type", "?")
+        fv = v.get("facet_value", "?")
+        code = v.get("code", "—")
+        source = v.get("source", "?")
+        desc = v.get("description", "")
+        scope = v.get("entity_scope", "")
+        src_class = "source-psh" if source == "PSH" else "source-local" if source == "project-local" else "source-schema"
+        active_rows += f"""
+        <tr>
+            <td>{fv}</td>
+            <td>{ft}</td>
+            <td style="color:#6e7681">{code}</td>
+            <td class="{src_class}">{source}</td>
+            <td style="color:#6e7681;font-size:0.85em">{desc[:60]}</td>
+        </tr>"""
+
+    inactive_rows = ""
+    for v in inactive_vocab:
+        fv = v.get("facet_value", "?")
+        code = v.get("code", "—")
+        desc = v.get("description", "")
+        inactive_rows += f"""
+        <tr style="color:#484f58">
+            <td>{fv}</td>
+            <td style="color:#6e7681">{code}</td>
+            <td>{desc}</td>
+        </tr>"""
+
+    # Version distribution
+    version_rows = ""
+    for v in version_dist:
+        ver = v.get("keyword_set_version", "?")
+        version_rows += f"""
+        <tr>
+            <td>v{ver if ver else 'legacy'}</td>
+            <td style="text-align:right">{v.get('facet_count', 0)}</td>
+            <td style="color:#6e7681">{v.get('oldest', '—')}</td>
+            <td style="color:#6e7681">{v.get('newest', '—')}</td>
+        </tr>"""
+
+    total_facets = sum(d.get("entity_count", 0) for d in psh_dist) + sum(d.get("entity_count", 0) for d in schema_dist)
+    active_categories = len([d for d in psh_dist if d.get("facet_value") != "unclassified"])
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="30">
+    <title>Mesh Status — {status['agent_id']}</title>
+    <style>
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+        body {{
+            font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+            background: #0d1117; color: #c9d1d9;
+            padding: 20px; line-height: 1.5;
+        }}
+        h1 {{ color: #58a6ff; font-size: 1.4em; margin-bottom: 4px; }}
+        h2 {{
+            color: #8b949e; font-size: 1.0em; margin: 24px 0 8px 0;
+            border-bottom: 1px solid #21262d; padding-bottom: 4px;
+        }}
+        .subtitle {{ color: #8b949e; font-size: 0.85em; margin-bottom: 20px; }}
+        .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin-bottom: 20px; }}
+        .card {{
+            background: #161b22; border: 1px solid #21262d;
+            border-radius: 6px; padding: 12px;
+        }}
+        .card-label {{ color: #8b949e; font-size: 0.75em; text-transform: uppercase; letter-spacing: 0.05em; }}
+        .card-value {{ color: #f0f6fc; font-size: 1.6em; font-weight: bold; margin-top: 2px; }}
+        .card-detail {{ color: #8b949e; font-size: 0.8em; margin-top: 4px; }}
+        .budget-bar {{
+            width: 100%; height: 8px; background: #21262d;
+            border-radius: 4px; margin-top: 6px; overflow: hidden;
+        }}
+        .budget-fill {{
+            height: 100%; border-radius: 4px;
+            transition: width 0.5s ease;
+        }}
+        table {{
+            width: 100%; border-collapse: collapse;
+            background: #161b22; border: 1px solid #21262d;
+            border-radius: 6px; overflow: hidden;
+            font-size: 0.85em; margin-bottom: 16px;
+        }}
+        th {{
+            text-align: left; padding: 8px 10px;
+            background: #1c2128; color: #8b949e;
+            font-weight: normal; font-size: 0.8em;
+            text-transform: uppercase; letter-spacing: 0.05em;
+        }}
+        td {{ padding: 6px 10px; border-top: 1px solid #21262d; }}
+        tr.pending td {{ color: #f0f6fc; }}
+        tr.processed td {{ color: #6e7681; }}
+        .empty {{ color: #484f58; text-align: center; font-style: italic; padding: 16px; }}
+        .tier-active {{ color: #3fb950; font-weight: bold; }}
+        .tier-warm {{ color: #d29922; }}
+        .tier-cold {{ color: #484f58; }}
+        .result-approved {{ color: #3fb950; }}
+        .result-blocked {{ color: #f85149; }}
+        .alert {{ color: #f85149; font-weight: bold; }}
+        .ok {{ color: #3fb950; }}
+        .accordion-header {{ cursor: pointer; }}
+        .accordion-header:hover td {{ background: #1c2128; }}
+        .accordion-detail td {{ background: #0d1117 !important; padding: 12px 16px; }}
+        .detail-grid {{
+            display: grid; grid-template-columns: 1fr 1fr;
+            gap: 6px 24px; font-size: 0.9em;
+        }}
+        .detail-label {{ color: #8b949e; }}
+        .schedule-row {{ display: flex; gap: 24px; flex-wrap: wrap; }}
+        .schedule-item {{ flex: 1; min-width: 180px; }}
+        .schedule-label {{ color: #8b949e; font-size: 0.75em; text-transform: uppercase; }}
+        .schedule-value {{ color: #c9d1d9; font-size: 0.95em; margin-top: 2px; }}
+        .lock-active {{ color: #d29922; }}
+        .lock-stale {{ color: #f85149; }}
+        footer {{
+            margin-top: 32px; padding-top: 12px;
+            border-top: 1px solid #21262d;
+            color: #484f58; font-size: 0.75em;
+        }}
+        .tabs {{
+            display: flex; gap: 0; margin-bottom: 20px;
+            border-bottom: 2px solid #21262d;
+        }}
+        .tab {{
+            padding: 8px 20px; cursor: pointer;
+            color: #8b949e; font-size: 0.9em;
+            border-bottom: 2px solid transparent;
+            margin-bottom: -2px;
+        }}
+        .tab:hover {{ color: #c9d1d9; }}
+        .tab.active {{
+            color: #58a6ff; border-bottom-color: #58a6ff;
+            font-weight: bold;
+        }}
+        .tab-content {{ display: none; }}
+        .tab-content.active {{ display: block; }}
+        .psh-bar {{
+            height: 16px; border-radius: 3px;
+            background: #21262d; overflow: hidden;
+            margin-top: 2px;
+        }}
+        .psh-fill {{
+            height: 100%; border-radius: 3px;
+        }}
+        .source-psh {{ color: #58a6ff; }}
+        .source-local {{ color: #d29922; }}
+        .source-schema {{ color: #a371f7; }}
+        .active-badge {{ color: #3fb950; font-size: 0.8em; }}
+        .inactive-badge {{ color: #484f58; font-size: 0.8em; }}
+        .conf-low {{ color: #f85149; }}
+        .conf-mid {{ color: #d29922; }}
+        .conf-high {{ color: #3fb950; }}
+    </style>
+</head>
+<body>
+    <h1>⬡ Mesh Status — {status['agent_id']}</h1>
+    <div class="subtitle">
+        {status['collected_at']} · schema v{status['schema_version']} · auto-refresh 30s
+    </div>
+
+    <div class="tabs">
+        <div class="tab active" onclick="switchTab('mesh')">Mesh</div>
+        <div class="tab" onclick="switchTab('semiotics')">Semiotics</div>
+    </div>
+
+    <div id="tab-mesh" class="tab-content active">
+
+    <div class="grid">
+        <div class="card">
+            <div class="card-label">Trust Budget</div>
+            <div class="card-value" style="color: {budget_color}">{budget_current} / {budget_max}</div>
+            <div class="budget-bar"><div class="budget-fill" style="width: {budget_pct}%; background: {budget_color}"></div></div>
+            <div class="card-detail">Last action: {last_action or 'never'}</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Unprocessed</div>
+            <div class="card-value{' alert' if totals.get('unprocessed', 0) > 0 else ''}">{totals.get('unprocessed', 0)}</div>
+            <div class="card-detail">messages awaiting processing</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Active Gates</div>
+            <div class="card-value{' alert' if totals.get('active_gates', 0) > 0 else ''}">{totals.get('active_gates', 0)}</div>
+            <div class="card-detail">blocking exchanges</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Total Messages</div>
+            <div class="card-value">{totals.get('messages', 0)}</div>
+            <div class="card-detail">across {totals.get('sessions', 0)} sessions</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Epistemic Debt</div>
+            <div class="card-value">{totals.get('epistemic_flags_unresolved', 0)}</div>
+            <div class="card-detail">unresolved flags</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Consecutive Errors</div>
+            <div class="card-value{' alert' if consecutive_blocks and consecutive_blocks > 0 else ' ok'}">{consecutive_blocks}</div>
+            <div class="card-detail">{'shadow mode ON' if shadow_mode else 'live mode'}</div>
+        </div>
+    </div>
+
+    <h2>Sync Schedule</h2>
+    <div class="card" style="margin-bottom: 16px">
+        <div class="schedule-row">
+            <div class="schedule-item">
+                <div class="schedule-label">Cron interval</div>
+                <div class="schedule-value">{f"{schedule.get('cron_interval_min')} min" if schedule.get('cron_interval_min') else 'not configured'}</div>
+            </div>
+            <div class="schedule-item">
+                <div class="schedule-label">Min action interval</div>
+                <div class="schedule-value">{f"{schedule.get('min_action_interval_sec')}s" if schedule.get('min_action_interval_sec') else '?'}</div>
+            </div>
+            <div class="schedule-item">
+                <div class="schedule-label">Last sync</div>
+                <div class="schedule-value">{schedule.get('last_sync') or 'never'}</div>
+            </div>
+            <div class="schedule-item">
+                <div class="schedule-label">Next expected</div>
+                <div class="schedule-value">{schedule.get('next_expected') or '—'}</div>
+            </div>
+            <div class="schedule-item">
+                <div class="schedule-label">Lock</div>
+                <div class="schedule-value {'lock-active' if schedule.get('lock_active') else 'lock-stale' if schedule.get('lock_stale') else ''}">{
+                    f"PID {schedule.get('lock_pid')} (running)" if schedule.get('lock_active')
+                    else f"PID {schedule.get('lock_pid')} (stale)" if schedule.get('lock_stale')
+                    else 'none'
+                }</div>
+            </div>
+        </div>
+        {f'<div style="margin-top:8px; font-size:0.8em; color:#6e7681">{schedule.get("cron_entry", "")}</div>' if schedule.get('cron_entry') else ''}
+    </div>
+
+    <h2>Peers</h2>
+    <table>
+        <tr><th>Agent</th><th>Role</th><th>Tier</th><th>Last Exchange</th><th>Messages</th></tr>
+        {peers_html or '<tr><td colspan="5" class="empty">No peer activity recorded</td></tr>'}
+    </table>
+
+    <h2>Unprocessed Queue</h2>
+    <table>
+        <tr><th></th><th>From</th><th>Session</th><th>Turn</th><th>Type</th><th>Timestamp</th></tr>
+        {unprocessed_html}
+    </table>
+
+    <h2>Active Gates</h2>
+    <table>
+        <tr><th>Gate ID</th><th>Receiving Agent</th><th>Session</th><th>Timeout At</th><th>Fallback</th></tr>
+        {gates_html}
+    </table>
+
+    <h2>Recent Messages</h2>
+    <table>
+        <tr><th></th><th></th><th>From</th><th>To</th><th>Session</th><th>Turn</th><th>Type</th></tr>
+        {recent_html}
+    </table>
+
+    <h2>Autonomous Actions</h2>
+    <table>
+        <tr><th></th><th>Type</th><th>Result</th><th>Tier</th><th>Cost</th><th>Time</th></tr>
+        {actions_html}
+    </table>
+
+    <h2>Remote Peer State</h2>
+    <table>
+        <tr><th>Agent</th><th>Budget</th><th>Unprocessed</th><th>Gates</th><th>Messages</th><th>Epi Flags</th><th>Schema</th><th>Snapshot</th></tr>
+        {remote_html}
+    </table>
+
+    </div><!-- end tab-mesh -->
+
+    <div id="tab-semiotics" class="tab-content">
+
+    <div class="grid">
+        <div class="card">
+            <div class="card-label">Total Facets</div>
+            <div class="card-value">{total_facets}</div>
+            <div class="card-detail">PSH + schema.org</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Active PSH Categories</div>
+            <div class="card-value">{active_categories}</div>
+            <div class="card-detail">of 44 PSH + project-local</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Inactive PSH Available</div>
+            <div class="card-value">{len(inactive_vocab)}</div>
+            <div class="card-detail">awaiting literary warrant</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Low Confidence</div>
+            <div class="card-value{' alert' if low_conf > 50 else ''}">{low_conf}</div>
+            <div class="card-detail">facets with conf &lt; 0.05</div>
+        </div>
+    </div>
+
+    <h2>PSH Subject Distribution</h2>
+    <table>
+        <tr><th>Category</th><th>Code</th><th style="text-align:right">Entities</th><th style="text-align:right">Avg Conf</th><th>Distribution</th></tr>
+        {psh_rows or '<tr><td colspan="5" class="empty">No PSH facets found</td></tr>'}
+    </table>
+
+    <h2>Schema.org Type Distribution</h2>
+    <table>
+        <tr><th>Type</th><th style="text-align:right">Entities</th></tr>
+        {schema_rows or '<tr><td colspan="2" class="empty">No schema.org facets found</td></tr>'}
+    </table>
+
+    <h2>Active Vocabulary Registry</h2>
+    <table>
+        <tr><th>Value</th><th>Type</th><th>Code</th><th>Source</th><th>Description</th></tr>
+        {active_rows or '<tr><td colspan="5" class="empty">No vocabulary entries</td></tr>'}
+    </table>
+
+    <h2>Inactive PSH Categories (Available for Activation)</h2>
+    <table>
+        <tr><th>Category</th><th>Code</th><th>Description</th></tr>
+        {inactive_rows or '<tr><td colspan="3" class="empty">All categories active</td></tr>'}
+    </table>
+
+    <h2>Keyword Set Versions</h2>
+    <table>
+        <tr><th>Version</th><th style="text-align:right">Facets</th><th>Oldest</th><th>Newest</th></tr>
+        {version_rows or '<tr><td colspan="4" class="empty">No version data</td></tr>'}
+    </table>
+
+    </div><!-- end tab-semiotics -->
+
+    <script>
+    function switchTab(tabName) {{
+        document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
+        document.querySelectorAll('.tab').forEach(el => el.classList.remove('active'));
+        document.getElementById('tab-' + tabName).classList.add('active');
+        document.querySelector('.tab[onclick*="' + tabName + '"]').classList.add('active');
+    }}
+    function toggleRow(id) {{
+        const row = document.getElementById(id);
+        const header = row.previousElementSibling;
+        const arrow = header.querySelector('td:first-child');
+        if (row.style.display === 'none') {{
+            row.style.display = 'table-row';
+            arrow.textContent = '▾';
+        }} else {{
+            row.style.display = 'none';
+            arrow.textContent = '▸';
+        }}
+    }}
+    </script>
+
+    <footer>
+        {status['db_path']} · {'db exists' if status['db_exists'] else 'DB MISSING'}
+    </footer>
+</body>
+</html>"""
+
+
+# ── HTTP Server ──────────────────────────────────────────────────────────
+
+class StatusHandler(BaseHTTPRequestHandler):
+    """Serve the mesh status dashboard."""
+
+    def do_GET(self):
+        status = collect_status()
+
+        if self.path == "/api/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(json.dumps(status, indent=2).encode())
+        else:
+            html = render_html(status)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(html.encode())
+
+    def log_message(self, format, *args):
+        """Suppress default request logging."""
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mesh status dashboard")
+    parser.add_argument("--port", type=int, default=8077,
+                        help="HTTP port (default: 8077)")
+    parser.add_argument("--json", action="store_true",
+                        help="Dump status as JSON and exit (no server)")
+    args = parser.parse_args()
+
+    if args.json:
+        print(json.dumps(collect_status(), indent=2))
+        return
+
+    server = HTTPServer(("0.0.0.0", args.port), StatusHandler)
+    print(f"Mesh status dashboard: http://localhost:{args.port}")
+    print(f"JSON API: http://localhost:{args.port}/api/status")
+    print(f"Reading from: {DB_PATH}")
+    print("Press Ctrl+C to stop.")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -329,3 +329,184 @@ VALUES ('active_gates', 'private', 'Gate state — machine-specific operational 
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (10, 'Add active_gates table — gated autonomous chain tracking with timeout and fallback cascade');
+
+
+-- ── Schema v11: Transport duplicate prevention ──────────────────────
+
+-- Turn numbers are per-agent within a session, not globally unique per session.
+-- Two agents in the same session legitimately share turn numbers (concurrent
+-- assignment without a shared counter). The correct uniqueness constraint:
+-- no agent writes the same turn twice in the same session.
+--
+-- NOTE: Historical data contains same-agent turn collisions (pre-v11 data
+-- assigned turns from filenames, not state.db). The unique index cannot be
+-- created if collisions exist. Use bootstrap_state_db.py --force to rebuild
+-- from source files with corrected turns, or fix collisions manually before
+-- applying. The index creation will silently fail on DBs with collisions —
+-- future writes still benefit from the next-turn subcommand in dual_write.py.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transport_agent_turn_unique
+    ON transport_messages (session_name, from_agent, turn);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (11, 'Unique index on (session_name, from_agent, turn) + next-turn subcommand — prevents same-agent turn collisions going forward');
+
+
+-- ── Schema v12: Universal facets (dual-vocabulary classification) ─────
+--
+-- Plan 9 insight: disciplines are namespaces, not directories. Every entity
+-- in the state layer gains facets. Query composes the view.
+--
+-- Universal facets decouple from memory_entries — any entity type (transport
+-- messages, decisions, lessons, sessions, memory entries) can carry facets.
+-- No FK constraint (SQLite cannot enforce polymorphic FKs); integrity by
+-- application convention.
+--
+-- Two vocabularies:
+--   psh         — PSH subject categories (Czech National Library, L1 + project-local)
+--                 10 active PSH categories + PL-001 (ai-systems). L2-ready via
+--                 slash-separated values (e.g., 'psychology/psychometrics').
+--   schema_type — schema.org type per entity table (Message, Claim, Event, etc.)
+--
+-- Bootstrap: scripts/bootstrap_facets.py (replaces bootstrap_pje_facets.py)
+-- Discovery: --discover mode surfaces vocabulary gaps via literary warrant.
+
+CREATE TABLE IF NOT EXISTS universal_facets (
+    entity_type TEXT NOT NULL,       -- table name: 'transport_messages', 'decision_chain', etc.
+    entity_id   INTEGER NOT NULL,    -- row id in the source table
+    facet_type  TEXT NOT NULL,        -- 'psh', 'schema_type', 'domain', 'agent', 'work_stream', etc.
+    facet_value TEXT NOT NULL,
+    confidence          REAL DEFAULT 1.0,    -- keyword match strength (0.0–1.0)
+    keyword_hits        TEXT,                -- JSON array of matched keywords (nullable)
+    computed_at         TEXT,                -- when this facet was last computed
+    keyword_set_version INTEGER DEFAULT 1,   -- which keyword set version produced this facet
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime')),
+    PRIMARY KEY (entity_type, entity_id, facet_type, facet_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_uf_facet_lookup
+    ON universal_facets (facet_type, facet_value);
+
+CREATE INDEX IF NOT EXISTS idx_uf_entity
+    ON universal_facets (entity_type, entity_id);
+
+CREATE INDEX IF NOT EXISTS idx_uf_psh
+    ON universal_facets (facet_value) WHERE facet_type = 'psh';
+
+CREATE INDEX IF NOT EXISTS idx_uf_schema_type
+    ON universal_facets (facet_value) WHERE facet_type = 'schema_type';
+
+-- Migrate existing entry_facets into universal_facets
+INSERT OR IGNORE INTO universal_facets (entity_type, entity_id, facet_type, facet_value)
+    SELECT 'memory_entries', entry_id, facet_type, facet_value FROM entry_facets;
+
+INSERT OR IGNORE INTO table_visibility (table_name, default_visibility, description)
+VALUES ('universal_facets', 'shared', 'Cross-entity facets — PSH subjects, schema.org types, agents, work streams. Shared because facet types and values are public vocabulary.');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (12, 'Universal facets — polymorphic entity tagging. Dual vocabulary: PSH subjects (11 L1 categories incl. PL-001 ai-systems) + schema.org types. Replaces PJE taxonomy and entry_facets FK-bound pattern.');
+
+
+-- ── Schema v13: Facet vocabulary reference table ─────────────────────
+--
+-- Queryable source of truth for PSH categories and schema.org types.
+-- bootstrap_facets.py Python constants remain the write-time implementation;
+-- this table provides the queryable, shared registry that other scripts
+-- and downstream consumers can read without importing Python.
+--
+-- Visibility: shared — these represent public vocabulary definitions.
+
+CREATE TABLE IF NOT EXISTS facet_vocabulary (
+    facet_type      TEXT NOT NULL,        -- 'psh' or 'schema_type'
+    facet_value     TEXT NOT NULL,        -- e.g., 'psychology', 'schema:Message'
+    code            TEXT,                 -- PSH code (e.g., 'PSH9194') or null for schema.org
+    source          TEXT NOT NULL,        -- 'PSH', 'schema.org', or 'project-local'
+    description     TEXT,                 -- human-readable description
+    entity_scope    TEXT,                 -- for schema_type: which table(s) carry this type
+    active          INTEGER NOT NULL DEFAULT 1,  -- 0 = retired (e.g., pje_domain)
+    keyword_count   INTEGER DEFAULT 0,   -- number of keywords in the classification set
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime')),
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime')),
+    PRIMARY KEY (facet_type, facet_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fv_active
+    ON facet_vocabulary (facet_type) WHERE active = 1;
+
+-- Seed PSH categories
+INSERT OR IGNORE INTO facet_vocabulary (facet_type, facet_value, code, source, description, keyword_count) VALUES
+    ('psh', 'psychology',          'PSH9194',  'PSH',           'Empirical, measurement, constructs, calibration, human factors',  43),
+    ('psh', 'law',                 'PSH8808',  'PSH',           'Governance, obligations, precedent, rights, due process',          35),
+    ('psh', 'computer-technology', 'PSH12314', 'PSH',           'Systems, specs, architecture, transport, databases',               32),
+    ('psh', 'information-science', 'PSH6445',  'PSH',           'Memory, indexing, classification, metadata, provenance',           20),
+    ('psh', 'systems-theory',      'PSH11322', 'PSH',           'Cogarch, feedback, emergence, cascade, self-healing',              11),
+    ('psh', 'philosophy',          'PSH2596',  'PSH',           'Epistemology, fair witness, falsifiability, evidence, warrant',     13),
+    ('psh', 'sociology',           'PSH9508',  'PSH',           'Dignity index, cultural, community, audience, stakeholder',          8),
+    ('psh', 'mathematics',         'PSH7093',  'PSH',           'Calibration, regression, factor analysis, statistical methods',     13),
+    ('psh', 'communications',      'PSH9759',  'PSH',           'Interagent protocol, transport, mesh, sync, notification',          12),
+    ('psh', 'pedagogy',            'PSH8126',  'PSH',           'Socratic method, jargon policy, learning, onboarding',              10),
+    ('psh', 'ai-systems',          'PL-001',   'project-local', 'LLM, multi-agent, tool use, alignment — no PSH equivalent',         17);
+
+-- Seed schema.org types
+INSERT OR IGNORE INTO facet_vocabulary (facet_type, facet_value, code, source, description, entity_scope) VALUES
+    ('schema_type', 'schema:Message',          NULL, 'schema.org', 'Transport messages between agents',           'transport_messages'),
+    ('schema_type', 'schema:ChooseAction',     NULL, 'schema.org', 'Resolved design decisions',                   'decision_chain'),
+    ('schema_type', 'schema:Event',            NULL, 'schema.org', 'Session log entries',                         'session_log'),
+    ('schema_type', 'schema:Claim',            NULL, 'schema.org', 'Verified claims from transport',              'claims'),
+    ('schema_type', 'schema:DefinedTerm',      NULL, 'schema.org', 'Memory entries — structured knowledge',       'memory_entries'),
+    ('schema_type', 'schema:LearningResource', NULL, 'schema.org', 'Lessons — transferable patterns',             'lessons'),
+    ('schema_type', 'schema:HowToStep',        NULL, 'schema.org', 'Cognitive triggers — operational procedures', 'trigger_state'),
+    ('schema_type', 'schema:Action',           NULL, 'schema.org', 'Autonomous actions audit trail',              'autonomous_actions'),
+    ('schema_type', 'schema:SuspendAction',    NULL, 'schema.org', 'Active gates — blocking operations',          'active_gates'),
+    ('schema_type', 'schema:Comment',          NULL, 'schema.org', 'Epistemic flags — quality concerns',          'epistemic_flags');
+
+-- Seed inactive PSH categories (the remaining 33 of 44) — available for
+-- intelligent discovery: --discover matches unclassified entity clusters
+-- against these descriptions to recommend activations.
+INSERT OR IGNORE INTO facet_vocabulary (facet_type, facet_value, code, source, description, active) VALUES
+    ('psh', 'anthropology',          'PSH1',     'PSH', 'Human cultures, ethnography, cultural practices',            0),
+    ('psh', 'architecture',          'PSH116',   'PSH', 'Building design, city planning, urban development',          0),
+    ('psh', 'astronomy',             'PSH320',   'PSH', 'Celestial objects, space, cosmic phenomena',                 0),
+    ('psh', 'biology',               'PSH573',   'PSH', 'Life sciences, organisms, ecology, evolution',               0),
+    ('psh', 'chemistry',             'PSH5450',  'PSH', 'Chemical compounds, reactions, molecular science',           0),
+    ('psh', 'transport',             'PSH1038',  'PSH', 'Transportation systems, logistics, vehicles',                0),
+    ('psh', 'economic-sciences',     'PSH1217',  'PSH', 'Economics, finance, trade, business',                        0),
+    ('psh', 'electronics',           'PSH1781',  'PSH', 'Electronic components, devices, circuits',                   0),
+    ('psh', 'electrical-engineering','PSH2086',  'PSH', 'Electrical systems, power distribution',                     0),
+    ('psh', 'energy',                'PSH2395',  'PSH', 'Energy sources, power generation, energy systems',           0),
+    ('psh', 'physics',               'PSH2910',  'PSH', 'Mechanics, thermodynamics, quantum physics',                 0),
+    ('psh', 'geophysics',            'PSH3768',  'PSH', 'Earth physics, seismology, planetary physics',               0),
+    ('psh', 'geography',             'PSH4231',  'PSH', 'Physical and human geography, regional studies',             0),
+    ('psh', 'geology',               'PSH4439',  'PSH', 'Rock formations, mineralogy, earth structure',               0),
+    ('psh', 'history',               'PSH5042',  'PSH', 'Historical events, periods, civilizations',                  0),
+    ('psh', 'metallurgy',            'PSH5176',  'PSH', 'Metal production, alloys, metal processing',                 0),
+    ('psh', 'computer-science',      'PSH6548',  'PSH', 'Computing, algorithms, software, information technology',    0),
+    ('psh', 'linguistics',           'PSH6641',  'PSH', 'Language structure, grammar, philology',                     0),
+    ('psh', 'literature',            'PSH6914',  'PSH', 'Books, poetry, literary works, criticism',                   0),
+    ('psh', 'religion',              'PSH7769',  'PSH', 'Theology, spirituality, faith traditions',                   0),
+    ('psh', 'general',               'PSH7979',  'PSH', 'Cross-disciplinary, general topics, miscellaneous',          0),
+    ('psh', 'political-science',     'PSH8308',  'PSH', 'Government, politics, political theory',                     0),
+    ('psh', 'food-industry',         'PSH8613',  'PSH', 'Food production, processing, nutrition',                     0),
+    ('psh', 'sports',                'PSH9899',  'PSH', 'Athletic activities, physical education, recreation',         0),
+    ('psh', 'consumer-industry',     'PSH10067', 'PSH', 'Consumer goods, retail, manufacturing',                      0),
+    ('psh', 'construction',          'PSH10355', 'PSH', 'Building construction, civil works',                         0),
+    ('psh', 'mechanical-engineering','PSH10652', 'PSH', 'Machinery, mechanical systems, engineering design',          0),
+    ('psh', 'mining',                'PSH11453', 'PSH', 'Mining, mineral extraction, mining technology',              0),
+    ('psh', 'art',                   'PSH11591', 'PSH', 'Visual arts, fine arts, aesthetics',                         0),
+    ('psh', 'water-management',      'PSH12008', 'PSH', 'Water systems, hydrology, water resources',                 0),
+    ('psh', 'military-affairs',      'PSH12156', 'PSH', 'Military science, warfare, defense',                        0),
+    ('psh', 'science-technology',    'PSH11939', 'PSH', 'General science, technology, applied research',              0),
+    ('psh', 'health-services',       'PSH12577', 'PSH', 'Medicine, healthcare, medical services, public health',      0),
+    ('psh', 'agriculture',           'PSH13220', 'PSH', 'Farming, crop production, livestock',                        0);
+
+-- Retire PJE vocabulary entries (historical record)
+INSERT OR IGNORE INTO facet_vocabulary (facet_type, facet_value, code, source, description, active) VALUES
+    ('pje_domain', 'psychology',    NULL, 'project-local', 'RETIRED 2026-03-10 — replaced by PSH facets', 0),
+    ('pje_domain', 'jurisprudence', NULL, 'project-local', 'RETIRED 2026-03-10 — replaced by PSH facets', 0),
+    ('pje_domain', 'engineering',   NULL, 'project-local', 'RETIRED 2026-03-10 — replaced by PSH facets', 0),
+    ('pje_domain', 'cross-cutting', NULL, 'project-local', 'RETIRED 2026-03-10 — replaced by PSH facets', 0);
+
+INSERT OR IGNORE INTO table_visibility (table_name, default_visibility, description)
+VALUES ('facet_vocabulary', 'shared', 'Vocabulary definitions for PSH categories and schema.org types — public reference data');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (13, 'Facet vocabulary reference table — queryable source of truth for PSH categories and schema.org types. Shared visibility. Retired PJE entries preserved with active=0.');

--- a/scripts/verify_shared_scripts.py
+++ b/scripts/verify_shared_scripts.py
@@ -22,6 +22,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = PROJECT_ROOT / "scripts" / "shared-scripts.json"
 REGISTRY_PATH = PROJECT_ROOT / "transport" / "agent-registry.json"
+REGISTRY_LOCAL_PATH = PROJECT_ROOT / "transport" / "agent-registry.local.json"
 
 
 def sha256_file(path: Path) -> str:
@@ -51,11 +52,29 @@ def load_manifest() -> dict:
     return json.loads(MANIFEST_PATH.read_text())
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge override into base (override wins on conflicts)."""
+    merged = base.copy()
+    for key, value in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def load_registry() -> dict:
-    """Load agent registry to map agent IDs to git remote names."""
+    """Load agent registry, merging local overrides if present."""
     if not REGISTRY_PATH.exists():
         return {}
-    return json.loads(REGISTRY_PATH.read_text())
+    registry = json.loads(REGISTRY_PATH.read_text())
+    if REGISTRY_LOCAL_PATH.exists():
+        try:
+            local = json.loads(REGISTRY_LOCAL_PATH.read_text())
+            registry = _deep_merge(registry, local)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return registry
 
 
 def get_remote_name(agent_id: str, registry: dict) -> str | None:
@@ -147,20 +166,23 @@ def update_manifest():
 
 
 def print_fix_commands(peer: str, divergences: list[dict]):
-    """Print scp commands to fix divergences."""
+    """Print scp commands to fix divergences (requires agent-registry.local.json)."""
     registry = load_registry()
     agent_config = registry.get("agents", {}).get(peer, {})
-    lan_host = agent_config.get("lan_host", f"{peer}.local")
-    lan_user = agent_config.get("lan_user", "kashif")
+    lan_host = agent_config.get("lan_host")
+    lan_user = agent_config.get("lan_user")
+    remote_root = agent_config.get("remote_project_root")
 
-    # Try to determine remote project root from registry
-    # Default: assume same relative path
-    remote_root = f"/home/{lan_user}/projects/psychology/safety-quotient"
+    if not lan_host or not remote_root:
+        print(f"Cannot generate fix commands for {peer}:")
+        print(f"  Missing lan_host or remote_project_root in agent-registry.local.json")
+        print(f"  Create transport/agent-registry.local.json with LAN details.")
+        return
 
     for d in divergences:
         if d.get("peer") == peer or peer in d.get("peers", []):
             local = PROJECT_ROOT / d["script"]
-            remote = f"{lan_host}:{remote_root}/{d['script']}"
+            remote = f"{lan_user}@{lan_host}:{remote_root}/{d['script']}"
             print(f"scp {local} {remote}")
 
 


### PR DESCRIPTION
## Summary

- **3 new scripts** from psychology-agent upstream: `mesh-state-export.py` (operational state export for cross-machine mesh visibility), `bootstrap_facets.py` (PSH + schema.org dual-vocabulary facet classification replacing PJE taxonomy), `mesh-status.py` (HTTP dashboard for mesh health monitoring)
- **4 updated scripts** synced to upstream: `schema.sql` (v11-v13: transport dedup index, universal_facets table, facet_vocabulary reference table), `autonomous-sync.sh` (pre-flight transport diff check, mesh-state export hook, TRANSPORT_CHANGED tracking), `verify_shared_scripts.py` and `cross_repo_fetch.py` (registry spec/instantiation split via `_deep_merge`, adaptive sync frequency with activity tier classification)
- **`.gitignore` updated** to exclude `transport/agent-registry.local.json` (machine-specific LAN overrides)

## Test plan

- [ ] Verify `scripts/schema.sql` applies cleanly to a fresh state.db (`sqlite3 state.db < scripts/schema.sql`)
- [ ] Verify `bootstrap_facets.py --dry-run` runs without import errors
- [ ] Verify `mesh-state-export.py --stdout` runs with an existing state.db
- [ ] Verify `mesh-status.py --json` runs with an existing state.db
- [ ] Verify `autonomous-sync.sh` parses without syntax errors (`bash -n scripts/autonomous-sync.sh`)
- [ ] Verify `verify_shared_scripts.py --quiet` runs without import errors
- [ ] Verify `cross_repo_fetch.py --json` runs without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)