### PR TITLE
feat: autonomous-sync token savings + max-turns fix

### DIFF
--- a/scripts/auto_process_trivial.py
+++ b/scripts/auto_process_trivial.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""auto_process_trivial.py — Auto-process transport messages that need no LLM review.
+
+Marks as processed any unprocessed message where:
+  - ack_required = FALSE (or absent), AND
+  - message_type IN ('ack', 'notification', 'state-update')
+
+These messages carry no substance decision — they inform but don't request.
+Messages requiring LLM review (requests, proposals, gated responses) survive
+for claude /sync to handle.
+
+Usage:
+    python3 scripts/auto_process_trivial.py          # process and report
+    python3 scripts/auto_process_trivial.py --dry-run # report without processing
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_ROOT / "state.db"
+
+# Message types safe to auto-process without LLM review
+TRIVIAL_TYPES = ('ack', 'notification', 'state-update')
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-process trivial transport messages")
+    parser.add_argument("--dry-run", action="store_true", help="Report without processing")
+    args = parser.parse_args()
+
+    if not DB_PATH.exists():
+        return
+
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+
+    # Find trivial unprocessed messages
+    placeholders = ",".join("?" for _ in TRIVIAL_TYPES)
+    rows = conn.execute(
+        f"SELECT filename, message_type, from_agent, session_name "
+        f"FROM transport_messages "
+        f"WHERE processed = FALSE "
+        f"AND (ack_required = 0 OR ack_required IS NULL) "
+        f"AND message_type IN ({placeholders})",
+        TRIVIAL_TYPES
+    ).fetchall()
+
+    if not rows:
+        conn.close()
+        return
+
+    if args.dry_run:
+        for r in rows:
+            print(f"would process: {r['filename']} ({r['message_type']} from {r['from_agent']})")
+        conn.close()
+        return
+
+    # Mark as processed
+    for r in rows:
+        conn.execute(
+            "UPDATE transport_messages SET processed = TRUE, "
+            "processed_at = strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime') "
+            "WHERE filename = ?",
+            (r["filename"],)
+        )
+
+    conn.commit()
+    conn.close()
+
+    count = len(rows)
+    types = ", ".join(sorted(set(r["message_type"] for r in rows)))
+    print(f"{count} trivial ({types})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/autonomous-sync.sh
+++ b/scripts/autonomous-sync.sh
@@ -366,13 +366,7 @@ run_sync() {
 
     log "Running /sync --autonomous..." >&2
 
-    # Pull cross-repo inbound messages into state.db before orientation
-    if [ -f "${PROJECT_ROOT}/scripts/cross_repo_fetch.py" ]; then
-        log "Fetching cross-repo transport..." >&2
-        python3 "${PROJECT_ROOT}/scripts/cross_repo_fetch.py" --index 2>/dev/null || {
-            err "cross_repo_fetch.py failed — continuing without cross-repo inbound"
-        }
-    fi
+    # cross_repo_fetch already ran before pre-flight — skip here.
 
     # Generate orientation payload from state.db
     local orientation
@@ -390,15 +384,29 @@ run_sync() {
     fi
 
     local sync_output
+    local claude_exit
     sync_output=$(claude -p "${prompt}" \
         --allowedTools "Read,Write,Edit,Glob,Grep,Bash" \
         --permission-mode "bypassPermissions" \
-        --max-turns 30 \
-        2>&1) || {
-        err "claude CLI exited with error"
-        echo "${sync_output}" | tail -20
-        return 1
-    }
+        --max-turns 80 \
+        2>&1)
+    claude_exit=$?
+
+    if [ "${claude_exit}" -ne 0 ]; then
+        # Distinguish max-turns (partial success) from real failures
+        if echo "${sync_output}" | grep -qi "max turns\|Reached max"; then
+            log "WARNING: claude CLI hit max-turns limit — partial sync completed"
+            # Partial success — don't treat as failure
+        elif echo "${sync_output}" | grep -qi "usage\|credit\|limit\|billing\|exceeded"; then
+            err "HALT — API usage limit reached. Check billing/extra usage settings."
+            echo "${sync_output}" | tail -5
+            return 1
+        else
+            err "claude CLI exited with error (code ${claude_exit})"
+            echo "${sync_output}" | tail -20
+            return 1
+        fi
+    fi
 
     echo "${sync_output}"
     return 0
@@ -492,9 +500,31 @@ main() {
         exit 1
     fi
 
+    # Index cross-repo inbound messages BEFORE pre-flight check.
+    # cross_repo_fetch uses git fetch (not git pull), so new peer messages
+    # won't appear in TRANSPORT_CHANGED. Indexing first ensures the
+    # unprocessed count in state.db reflects reality.
+    if [ -f "${PROJECT_ROOT}/scripts/cross_repo_fetch.py" ]; then
+        log "Fetching cross-repo transport..."
+        python3 "${PROJECT_ROOT}/scripts/cross_repo_fetch.py" --index 2>/dev/null || {
+            log "WARNING: cross_repo_fetch.py failed — continuing without cross-repo inbound"
+        }
+    fi
+
+    # Auto-process trivial messages in Python (no LLM needed).
+    # Marks as processed: ack_required=false AND type in (ack, notification).
+    # Only messages requiring substance review survive for claude /sync.
+    if [ -f "${PROJECT_ROOT}/scripts/auto_process_trivial.py" ]; then
+        local auto_result
+        auto_result=$(python3 "${PROJECT_ROOT}/scripts/auto_process_trivial.py" 2>/dev/null) || true
+        if [ -n "${auto_result}" ]; then
+            log "Auto-processed: ${auto_result}"
+        fi
+    fi
+
     # Pre-flight check: skip expensive claude invocation if nothing changed.
     # Still invoke if: transport changed, gates active, wake signal, or
-    # unprocessed messages exist in state.db.
+    # unprocessed messages exist in state.db (after cross-repo index + auto-process).
     if [ "${TRANSPORT_CHANGED}" = false ] && [ "${GATE_ACCELERATED}" = false ]; then
         local unprocessed_count
         unprocessed_count=$(sqlite3 "${DB_PATH}" \


### PR DESCRIPTION
## Summary

- **max-turns increased 30→80** — root cause of claude CLI failures during longer sync cycles; the CLI exited before completing work
- **Exit code classification** — distinguishes max-turns (partial success, no budget penalty) from credit exhaustion (halt) from real errors (retry with consecutive-error tracking)
- **cross_repo_fetch moved before pre-flight check** — fixes gap where cross-repo messages arrived via `git fetch` but weren't indexed before the unprocessed-count check, causing false no-ops
- **auto_process_trivial.py (NEW)** — auto-processes ack, notification, and state-update messages in Python without LLM invocation; only messages requiring substance review survive for claude /sync
- Typical quiet cycle now consumes **zero tokens** — trivial messages get marked processed before the pre-flight check, so the claude CLI never launches

## Files changed

- `scripts/autonomous-sync.sh` — max-turns, exit classification, cross-repo fetch reorder, auto-process hook
- `scripts/auto_process_trivial.py` — new file, trivial message auto-processor

## Test plan

- [ ] Verify `autonomous-sync.sh` runs with `--max-turns 80` on a quiet cycle (no unprocessed messages → no claude invocation)
- [ ] Verify `auto_process_trivial.py` marks ack/notification/state-update as processed
- [ ] Verify `auto_process_trivial.py --dry-run` reports without modifying state.db
- [ ] Confirm exit code classification: simulate max-turns output string → warning (not error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)