### PR TITLE
feat: migrate discovery URLs to safety-quotient.dev

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -33,8 +33,8 @@ Parse `$ARGUMENTS` to determine scope:
 
 | Agent | Repo | Agent Card | Transport | Relationship |
 |-------|------|------------|-----------|-------------|
-| psychology-agent | safety-quotient-lab/psychology-agent | (local only) | cross-repo-fetch | Parent orchestrator |
-| observatory-agent | safety-quotient-lab/observatory | https://observatory.unratified.org/.well-known/agent-card.json | git-PR | Peer (runs PSQ-Lite) |
+| psychology-agent | safety-quotient-lab/psychology-agent | https://psychology-agent.safety-quotient.dev/.well-known/agent-card.json | cross-repo-fetch | Parent orchestrator |
+| observatory-agent | safety-quotient-lab/observatory | https://observatory.safety-quotient.dev/.well-known/agent-card.json | git-PR | Peer (runs PSQ-Lite) |
 | unratified-agent | safety-quotient-lab/unratified | https://unratified.org/.well-known/agent-card.json | git-PR | Peer (hosting platform) |
 
 ## Protocol

--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -113,9 +113,9 @@
   "scope_boundary": "Validated for: English social media stress text, self-report format. Not validated for: clinical intake notes, therapist-authored text, non-English, non-WEIRD populations, texts > 128 tokens.",
 
   "inbox": "~/.claude/proposals/to-psq/",
-  "discovery_url": null,
-  "http_endpoint": "https://psq.unratified.org/score",
-  "http_health": "https://psq.unratified.org/health",
+  "discovery_url": "https://psq.safety-quotient.dev/.well-known/agent-card.json",
+  "http_endpoint": "https://psq.safety-quotient.dev/score",
+  "http_health": "https://psq.safety-quotient.dev/health",
 
   "namespace": "psy:psq",
   "tier": "PSQ-Full",

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -115,7 +115,7 @@ architecture, deploy procedure, and operational runbook.
 
 ```bash
 # Verify production endpoint is live
-curl https://psq.unratified.org/health
+curl https://psq.safety-quotient.dev/health
 
 # Deploy a new model version (after training + eval)
 source venv/bin/activate

--- a/deploy/hetzner-deploy.sh
+++ b/deploy/hetzner-deploy.sh
@@ -25,8 +25,8 @@ REMOTE_HOST="root@178.156.229.103"
 REMOTE_WORKING_DIR="/opt/psychology-agent/safety-quotient"
 REMOTE_MODEL_DIR="${REMOTE_WORKING_DIR}/models/psq-student"
 SERVICE_NAME="psq-server"
-HEALTH_URL="https://psq.unratified.org/health"
-SCORE_URL="https://psq.unratified.org/score"
+HEALTH_URL="https://psq.safety-quotient.dev/health"
+SCORE_URL="https://psq.safety-quotient.dev/score"
 
 LOCAL_STUDENT_DIR="models/psq-student"
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,7 @@ Last updated: 2026-03-08
 │  │  :443 TLS │     │  server.js :3000 │     │  Runtime   │  │
 │  └──────────┘     └──────────────────┘     └────────────┘  │
 │                                                             │
-│  psq.unratified.org  →  reverse_proxy localhost:3000        │
+│  psq.safety-quotient.dev  →  reverse_proxy localhost:3000   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -31,7 +31,7 @@ Last updated: 2026-03-08
 | Host | `178.156.229.103` |
 | User | `root` |
 | Auth | SSH key (on-disk, no password) |
-| DNS | `psq.unratified.org` |
+| DNS | `psq.safety-quotient.dev` |
 
 ```bash
 ssh root@178.156.229.103
@@ -45,7 +45,7 @@ ssh root@178.156.229.103
 Liveness check. Returns model readiness and calibration version.
 
 ```bash
-curl https://psq.unratified.org/health
+curl https://psq.safety-quotient.dev/health
 ```
 
 ```json
@@ -57,7 +57,7 @@ curl https://psq.unratified.org/health
 Score text across all 10 PSQ dimensions.
 
 ```bash
-curl -X POST https://psq.unratified.org/score \
+curl -X POST https://psq.safety-quotient.dev/score \
   -H "Content-Type: application/json" \
   -d '{"text": "The team felt safe raising concerns."}'
 ```
@@ -117,7 +117,7 @@ journalctl -u psq-server -n 100
 
 ```
 # /etc/caddy/Caddyfile
-psq.unratified.org {
+psq.safety-quotient.dev {
     reverse_proxy localhost:3000
 }
 ```
@@ -187,7 +187,7 @@ rsync -avz models/psq-student/{model_quantized.onnx,calibration.json,tokenizer/}
 ssh root@178.156.229.103 "systemctl restart psq-server"
 
 # 4. Verify
-curl https://psq.unratified.org/health
+curl https://psq.safety-quotient.dev/health
 ```
 
 
@@ -229,7 +229,7 @@ but has not been tested.
 **Health check (cron or external):**
 
 ```bash
-curl -sf https://psq.unratified.org/health | grep -q '"status":"ok"' || echo "PSQ DOWN"
+curl -sf https://psq.safety-quotient.dev/health | grep -q '"status":"ok"' || echo "PSQ DOWN"
 ```
 
 **No uptime monitoring is currently configured.** The service relies on systemd

--- a/docs/memory-snapshots/psq-status.md
+++ b/docs/memory-snapshots/psq-status.md
@@ -3,7 +3,7 @@
 
 # PSQ Sub-Agent Status (managed in its own context)
 
-**Production endpoint:** ✓ https://psq.unratified.org/score — live, TLS, Hetzner CX Ashburn
+**Production endpoint:** ✓ https://psq.safety-quotient.dev/score — live, TLS, Hetzner CX Ashburn
 **Score calibration:** ✓ isotonic-v2-2026-03-06. Quantile-binned isotonic (n_bins=20).
   All 10 dims calibrated. HI dead zone resolved (B2 (HI calibration dead zone) fix, Session 26).
   Historical MAE improvement: +3.5–21.6% per dimension vs. raw.
@@ -14,7 +14,7 @@
 **Model transfer:** ✓ rsync complete. SHA256 verified (Hetzner matches Chromebook source).
   41 files, 531 MB. best.pt on Hetzner; local copy lost.
 **Service:** systemd psq-server active. 84ms inference. onnxruntime-node postinstall fix.
-**Wrangler secret:** PSQ_ENDPOINT_URL → https://psq.unratified.org
+**Wrangler secret:** PSQ_ENDPOINT_URL → https://psq.safety-quotient.dev
 **Firewall:** ufw SSH + HTTP/HTTPS only. Port 3000 closed from public.
 **Integration:** psq-scoring session turn 7 complete — 5 ICESCR texts scored, B2 (HI calibration dead zone) validated.
 **B3 (TE uniformity) CLOSED 2026-03-07:**

--- a/transport/agent-registry.json
+++ b/transport/agent-registry.json
@@ -17,7 +17,7 @@
       "active_sessions": ["psq-scoring"],
       "always_consider": true,
       "autonomous": false,
-      "discovery_url": null,
+      "discovery_url": "https://psychology-agent.safety-quotient.dev/.well-known/agent-card.json",
       "notes": "Parent orchestrator. Cross-repo transport via git remote fetch — read MANIFEST via `git show psychology-agent/main:transport/MANIFEST.json`. Authority hierarchy: User > psychology-agent > PSQ."
     },
 
@@ -45,7 +45,7 @@
       "active_sessions": [],
       "always_consider": false,
       "autonomous": false,
-      "discovery_url": "https://observatory.unratified.org/.well-known/agent-card.json",
+      "discovery_url": "https://observatory.safety-quotient.dev/.well-known/agent-card.json",
       "notes": "Peer agent. PSQ-Lite consumer, content analysis."
     }
   },


### PR DESCRIPTION
## Summary
- Updates all agent discovery URLs from *.unratified.org to *.safety-quotient.dev
- psq-agent discovery: `psq.safety-quotient.dev`
- psychology-agent (parent): `psychology-agent.safety-quotient.dev`
- PSQ inference endpoint: `psq.safety-quotient.dev`
- API (CF Worker): `api.safety-quotient.dev`
- unratified-agent stays at unratified.org (owns that domain)

## Context
safety-quotient.dev purchased on Cloudflare (2026-03-10). Gives the lab its own domain namespace independent of peer agents and GitHub. All .dev domains enforce HTTPS via HSTS preload.

Psychology-agent side already updated (commit fb04193).

## Test plan
- [ ] Verify agent-card.json references correct subdomains
- [ ] Verify agent-registry.json points psychology-agent to new discovery URL
- [ ] DNS records configured in Cloudflare before going live

🤖 Generated with [Claude Code](https://claude.com/claude-code)