### PR TITLE
feat: preserve active tab on refresh via URL fragment

### DIFF
--- a/scripts/mesh-status.py
+++ b/scripts/mesh-status.py
@@ -1009,7 +1009,14 @@ def render_html(status: dict) -> str:
         document.querySelectorAll('.tab').forEach(el => el.classList.remove('active'));
         document.getElementById('tab-' + tabName).classList.add('active');
         document.querySelector('.tab[onclick*="' + tabName + '"]').classList.add('active');
+        window.location.hash = tabName;
     }}
+    (function() {{
+        const hash = window.location.hash.replace('#', '');
+        if (hash && document.getElementById('tab-' + hash)) {{
+            switchTab(hash);
+        }}
+    }})();
     function toggleRow(id) {{
         const row = document.getElementById(id);
         const header = row.previousElementSibling;


### PR DESCRIPTION
## Summary
- Add `window.location.hash = tabName` to `switchTab()` so each tab click updates the URL fragment
- Add an IIFE that reads the hash on page load and switches to the matching tab
- Matches the psychology-agent dashboard behavior for URL fragment tab persistence

## Test plan
- [ ] Run `mesh-status.py` and verify clicking tabs updates the URL hash
- [ ] Copy a URL with a hash fragment, open in a new tab, and confirm the correct tab activates
- [ ] Verify a nonexistent hash fragment falls back to the default tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)