### PR TITLE
fix: handle HEAD requests in mesh dashboard (501 → 200)

### DIFF
--- a/scripts/mesh-status.py
+++ b/scripts/mesh-status.py
@@ -1059,6 +1059,12 @@ class StatusHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(html.encode())
 
+    def do_HEAD(self):
+        """Handle HEAD requests (Cloudflare tunnel health checks)."""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+
     def log_message(self, format, *args):
         """Suppress default request logging."""
         pass


### PR DESCRIPTION
## Summary
- Add `do_HEAD` method to mesh-status dashboard HTTP handler
- Python's `BaseHTTPRequestHandler` returns 501 on HEAD by default
- Cloudflare tunnel health checks use HEAD, causing false unhealthy signals

## Test plan
- [ ] Verify `curl -I http://localhost:<port>` returns 200 instead of 501
- [ ] Confirm Cloudflare tunnel health checks report healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)