### PR TITLE
sync: shared infrastructure scripts from psychology-agent (Session 66)

### DIFF
--- a/scripts/dual_write.py
+++ b/scripts/dual_write.py
@@ -40,6 +40,17 @@ Usage:
 
     python scripts/dual_write.py gate-status [--agent-id AID]
 
+    python scripts/dual_write.py next-turn --session SESSION
+
+    python scripts/dual_write.py engineering-incident --incident-type TYPE \
+        --description TEXT [--session-id N] [--severity low|moderate|high|critical] \
+        [--tool-name NAME] [--tool-context CTX] [--detection-tier 1|2]
+
+    python scripts/dual_write.py facet --entity-type TABLE --entity-id N \
+        --facet-type TYPE --facet-value VALUE
+
+    python scripts/dual_write.py facet-query --facet-type TYPE --facet-value VALUE
+
 Requires: Python 3.10+ (stdlib only)
 """
 import argparse
@@ -337,6 +348,100 @@ def cmd_gate_status(args: argparse.Namespace) -> None:
     conn.close()
 
 
+# ── next-turn ────────────────────────────────────────────────────────────
+
+def cmd_next_turn(args: argparse.Namespace) -> None:
+    """Print the next available turn number for a session.
+
+    Computes MAX(turn) + 1 from transport_messages for the given session,
+    across ALL agents (turns are session-scoped, not agent-scoped, even
+    though two agents may have historically shared turn numbers). All
+    transport-writing skills should use this instead of parsing filenames
+    or directory listings.
+    """
+    conn = get_connection()
+    row = conn.execute(
+        "SELECT MAX(turn) FROM transport_messages WHERE session_name = ?",
+        (args.session,)
+    ).fetchone()
+    max_turn = row[0] if row and row[0] is not None else 0
+    next_turn = max_turn + 1
+    print(next_turn)
+    conn.close()
+
+
+# ── engineering-incident ──────────────────────────────────────────────────
+
+def cmd_engineering_incident(args: argparse.Namespace) -> None:
+    """Record an engineering incident, incrementing recurrence on duplicate type."""
+    conn = get_connection()
+    # Check if same incident_type already exists (for recurrence increment)
+    row = conn.execute(
+        "SELECT id, recurrence FROM engineering_incidents "
+        "WHERE incident_type = ? AND graduated = 0 "
+        "ORDER BY created_at DESC LIMIT 1",
+        (args.incident_type,)
+    ).fetchone()
+    if row:
+        conn.execute(
+            "UPDATE engineering_incidents SET recurrence = ?, "
+            "description = ?, tool_name = ?, tool_context = ?, "
+            "session_id = ?, severity = ? "
+            "WHERE id = ?",
+            (row[1] + 1, args.description, args.tool_name,
+             args.tool_context, args.session_id, args.severity or "moderate",
+             row[0])
+        )
+        print(f"incremented: engineering_incidents/{args.incident_type} "
+              f"(recurrence={row[1] + 1})")
+    else:
+        conn.execute(
+            "INSERT INTO engineering_incidents "
+            "(session_id, incident_type, detection_tier, severity, "
+            "description, tool_name, tool_context) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (args.session_id, args.incident_type,
+             args.detection_tier or 1, args.severity or "moderate",
+             args.description, args.tool_name, args.tool_context)
+        )
+        print(f"recorded: engineering_incidents/{args.incident_type}")
+    conn.commit()
+    conn.close()
+
+
+def cmd_facet(args: argparse.Namespace) -> None:
+    """Add a universal facet to any entity."""
+    conn = get_connection()
+    conn.execute(
+        "INSERT OR IGNORE INTO universal_facets "
+        "(entity_type, entity_id, facet_type, facet_value) "
+        "VALUES (?, ?, ?, ?)",
+        (args.entity_type, args.entity_id, args.facet_type, args.facet_value),
+    )
+    conn.commit()
+    conn.close()
+    print(f"facet: {args.entity_type}/{args.entity_id} "
+          f"+{args.facet_type}={args.facet_value}")
+
+
+def cmd_facet_query(args: argparse.Namespace) -> None:
+    """Query entities by facet type and value. Returns JSON."""
+    conn = get_connection()
+    rows = conn.execute(
+        "SELECT entity_type, entity_id, facet_type, facet_value "
+        "FROM universal_facets WHERE facet_type = ? AND facet_value = ? "
+        "ORDER BY entity_type, entity_id",
+        (args.facet_type, args.facet_value),
+    ).fetchall()
+    conn.close()
+    results = [
+        {"entity_type": r[0], "entity_id": r[1],
+         "facet_type": r[2], "facet_value": r[3]}
+        for r in rows
+    ]
+    print(json.dumps(results, indent=2))
+
+
 # ── main ─────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -428,6 +533,47 @@ def main() -> None:
     gs = sub.add_parser("gate-status", help="Show active gates (JSON)")
     gs.add_argument("--agent-id")
 
+    # next-turn
+    nt = sub.add_parser("next-turn",
+                        help="Print the next available turn number for a session")
+    nt.add_argument("--session", required=True)
+
+    # engineering-incident
+    ei = sub.add_parser("engineering-incident",
+                        help="Record an engineering anti-pattern incident")
+    ei.add_argument("--incident-type", required=True,
+                    help="Category: credential-exposure, dns-churn, error-loop, "
+                         "premature-execution, stale-process")
+    ei.add_argument("--description", required=True,
+                    help="What happened (fair witness: facts only)")
+    ei.add_argument("--session-id", type=int)
+    ei.add_argument("--severity", default="moderate",
+                    choices=["low", "moderate", "high", "critical"])
+    ei.add_argument("--tool-name",
+                    help="Tool that triggered detection (e.g., Bash)")
+    ei.add_argument("--tool-context",
+                    help="Command or context that triggered detection")
+    ei.add_argument("--detection-tier", type=int, default=1,
+                    choices=[1, 2],
+                    help="1=mechanical (hook), 2=cognitive (T17)")
+
+    # facet
+    fa = sub.add_parser("facet", help="Add a universal facet to any entity")
+    fa.add_argument("--entity-type", required=True,
+                    help="Table name (e.g., transport_messages, decision_chain)")
+    fa.add_argument("--entity-id", required=True, type=int,
+                    help="Row id in the source table")
+    fa.add_argument("--facet-type", required=True,
+                    help="Facet type (e.g., pje_domain, domain, agent)")
+    fa.add_argument("--facet-value", required=True,
+                    help="Facet value (e.g., psychology, jurisprudence)")
+
+    # facet-query
+    fq = sub.add_parser("facet-query",
+                        help="Query entities by facet type and value (JSON)")
+    fq.add_argument("--facet-type", required=True)
+    fq.add_argument("--facet-value", required=True)
+
     args = parser.parse_args()
 
     dispatch = {
@@ -442,6 +588,10 @@ def main() -> None:
         "gate-resolve": cmd_gate_resolve,
         "gate-timeout": cmd_gate_timeout,
         "gate-status": cmd_gate_status,
+        "next-turn": cmd_next_turn,
+        "engineering-incident": cmd_engineering_incident,
+        "facet": cmd_facet,
+        "facet-query": cmd_facet_query,
     }
     dispatch[args.command](args)
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -510,3 +510,46 @@ VALUES ('facet_vocabulary', 'shared', 'Vocabulary definitions for PSH categories
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (13, 'Facet vocabulary reference table — queryable source of truth for PSH categories and schema.org types. Shared visibility. Retired PJE entries preserved with active=0.');
+
+
+-- ── Schema v14: Engineering incident detection ───────────────────────
+--
+-- Structured log of engineering anti-patterns detected during sessions.
+-- Two detection tiers:
+--   Tier 1 (mechanical): PostToolUse hook scans tool output for concrete
+--     patterns (credentials in arguments, resource churn, error loops).
+--   Tier 2 (cognitive): T17 trigger for agent self-assessment of reasoning
+--     patterns (premature execution, decision-before-grounding). Deferred.
+--
+-- Graduation pipeline: when incident_type accumulates ≥3 occurrences,
+-- draft anti-patterns.md entry for user review.
+--
+-- Deterministic key: (session_id, incident_type, tool_context) — same
+-- incident type from the same tool call in the same session won't duplicate.
+
+CREATE TABLE IF NOT EXISTS engineering_incidents (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id      INTEGER,
+    incident_type   TEXT NOT NULL,
+    detection_tier  INTEGER NOT NULL DEFAULT 1,
+    severity        TEXT NOT NULL DEFAULT 'moderate',
+    description     TEXT NOT NULL,
+    tool_name       TEXT,
+    tool_context    TEXT,
+    recurrence      INTEGER NOT NULL DEFAULT 1,
+    graduated       INTEGER NOT NULL DEFAULT 0,
+    graduated_to    TEXT,
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S', 'now', 'localtime'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_incidents_type
+    ON engineering_incidents (incident_type);
+
+CREATE INDEX IF NOT EXISTS idx_incidents_ungraduated
+    ON engineering_incidents (graduated) WHERE graduated = 0;
+
+INSERT OR IGNORE INTO table_visibility (table_name, default_visibility, description)
+VALUES ('engineering_incidents', 'private', 'Engineering anti-pattern log — machine-specific learning data');
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (14, 'Engineering incidents table — two-tier anti-pattern detection (mechanical hooks + cognitive triggers). Graduation pipeline to anti-patterns.md.');

--- a/scripts/shared-scripts.json
+++ b/scripts/shared-scripts.json
@@ -21,11 +21,11 @@
     },
     {
       "path": "scripts/dual_write.py",
-      "description": "Incremental state.db upserts (11 subcommands)",
+      "description": "Incremental state.db upserts (15 subcommands incl. engineering-incident, next-turn, facet)",
       "shared_with": [
         "safety-quotient"
       ],
-      "sha256": "f969dc09baee7666c1e82b29b754e883923a261b0dcd7d38c14a088cf5e57911"
+      "sha256": "a9a7b3f3c4cd6c72e98a0a57b952048d8e194795f5fa4df7e20a7d56f256ab23"
     },
     {
       "path": "scripts/heartbeat.py",
@@ -61,11 +61,11 @@
     },
     {
       "path": "scripts/schema.sql",
-      "description": "Full state.db schema (v10, 13 tables)",
+      "description": "Full state.db schema (v14, engineering_incidents table)",
       "shared_with": [
         "safety-quotient"
       ],
-      "sha256": "00966bbf589c7551e54858fd04ee8235b1ed583cf92c2ab931f4bd6a62d5939b"
+      "sha256": "5befbcf5523dda7b387b8d69bfbdb16086b754cbe09809266a49ab76c4d41463"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **schema.sql** updated to v14: adds `engineering_incidents` table for tracking engineering incident records in the state layer
- **dual_write.py** updated to v15: adds 4 new subcommands — `engineering-incident`, `next-turn`, `facet`, and `facet-query` — bringing the total from 11 to 15
- **shared-scripts.json** checksums and descriptions updated to match new file contents

Source of truth: `psychology-agent` repo, Session 66.

## Test plan

- [x] `python3 -c "compile(...)"` syntax verification passed
- [ ] Run `python3 scripts/verify_shared_scripts.py` to confirm checksums match
- [ ] Run `python3 scripts/bootstrap_state_db.py` to verify schema applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)