### PR TITLE
upgrade: A2A 1.0.0 + bearer auth + ZMQ declaration

### DIFF
--- a/.well-known/agent-card.json
+++ b/.well-known/agent-card.json
@@ -13,7 +13,7 @@
   ],
   "extensions": [
     {
-      "uri": "https://github.com/safety-quotient-lab/interagent-epistemic/v1",
+      "uri": "https://github.com/safety-quotient-lab/a2a-epistemic/v1",
       "required": false,
       "description": "Per-claim confidence, SETL, epistemic flags, action gate, correction mechanism."
     }
@@ -165,7 +165,34 @@
   "namespace": "psy:psq",
   "tier": "PSQ-Full",
   "tier_note": "PSQ-Full (10-dim, DistilBERT, validated) vs PSQ-Lite (3-dim, LLM heuristic, observatory-agent). Namespace resolution agreed in transport/sessions/item2-derivation/psq-lite-response-001.json.",
-  "protocolVersion": "0.3.0",
+  "protocolVersion": "1.0.0",
+  "supported_interfaces": ["interagent/v1"],
+  "security": {
+    "security_schemes": {
+      "git_transport": {
+        "scheme": "transport",
+        "transport": "git-PR",
+        "repo": "https://github.com/safety-quotient-lab/safety-quotient",
+        "requirement": "GitHub org membership — safety-quotient-lab",
+        "description": "Agent-to-agent mesh communication via git-PR transport"
+      },
+      "bearer_http": {
+        "scheme": "http",
+        "type": "bearer",
+        "note": "Bearer token auth for HTTP API endpoints. Tokens managed via Cloudflare Workers secrets."
+      }
+    }
+  },
+  "mesh": {
+    "transport": {
+      "method": "git-PR",
+      "repo": "https://github.com/safety-quotient-lab/safety-quotient",
+      "sessions_path": "transport/sessions/",
+      "zmq": null,
+      "zmq_pub": null,
+      "zmq_pub_note": "SEC-6: ZMQ PUB not yet configured — placeholder for future mesh pub/sub"
+    }
+  },
   "peers": [
     {
       "id": "operations-agent",


### PR DESCRIPTION
## Summary
- Upgrade agent card protocolVersion from 0.3.0 to 1.0.0
- Add `supported_interfaces: ["interagent/v1"]`
- Restructure security to use `security_schemes` with `git_transport` + `bearer_http` (aligned with psychology-agent format)
- Add `mesh.transport` block with ZMQ PUB placeholder (`zmq_pub: null`)
- Migrate extension URI from `interagent-epistemic` to `a2a-epistemic` pattern

All existing content (dimensions, validation, scoring, known_limitations, skills) preserved.

## Test plan
- [ ] Verify JSON parses without error
- [ ] Confirm all 10 dimensions, validation block, and known_limitations remain intact
- [ ] Confirm security_schemes matches psychology-agent pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)